### PR TITLE
Modify : 카카오 소셜 로그인 보안 강화

### DIFF
--- a/src/main/java/com/practice/OAuth2/config/AppProperties.java
+++ b/src/main/java/com/practice/OAuth2/config/AppProperties.java
@@ -5,14 +5,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import java.util.ArrayList;
 import java.util.List;
 
-@ConfigurationProperties(prefix = "app")
+@ConfigurationProperties(prefix = "app") // yml의 app 으로 시작하는 설정을 매핑
 public class AppProperties {
     private final Auth auth = new Auth();
     private final OAuth2 oauth2 = new OAuth2();
 
     public static class Auth {
         private String tokenSecret;
-        private long tokenExpirationMsec;
+        private long tokenExpirationMsec; // yml의 tokenExpirationMsec와 자동 매핑 (Setter 필요)
 
         public String getTokenSecret() {
             return tokenSecret;

--- a/src/main/java/com/practice/OAuth2/security/TokenAuthenticationFilter.java
+++ b/src/main/java/com/practice/OAuth2/security/TokenAuthenticationFilter.java
@@ -2,6 +2,7 @@ package com.practice.OAuth2.security;
 
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
@@ -48,10 +49,24 @@ public class TokenAuthenticationFilter extends OncePerRequestFilter {
     }
 
     private String getJwtFromRequest(HttpServletRequest request) {
+        
+        // API test or APP 용
         String bearerToken = request.getHeader("Authorization");
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7, bearerToken.length());
         }
+
+        // 2. 헤더에 없으면 쿠키에서 시도 (HttpOnly Cookie)
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                // SuccessHandler에서 설정한 쿠키 이름("access_token")
+                if ("access_token".equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+
         return null;
     }
 }

--- a/src/main/java/com/practice/OAuth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/practice/OAuth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -9,8 +9,7 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -43,14 +42,15 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         String token = tokenProvider.createToken(authentication);
 
-        // HttpOnly Cookie 생성
-        Cookie cookie = new Cookie("access_token", token);
-        cookie.setPath("/");
-        cookie.setHttpOnly(true); // JS 접근 불가 (XSS 방지)
-        // cookie.setSecure(true);   // HTTPS 전용 (배포 환경 필수)
-        cookie.setMaxAge((int) appProperties.getAuth().getTokenExpirationMsec() / 1000); // 토큰 유효시간과 쿠키 유효시간 일치
+        ResponseCookie cookie = ResponseCookie.from("access_token", token)
+                .path("/")
+                .httpOnly(true)
+//                .secure(true) // HTTPS 배포 시 필수
+                .maxAge(appProperties.getAuth().getTokenExpirationMsec() / 1000)
+                .sameSite("Lax") // 명시적으로 Lax 설정 (CSRF 방어)
+                .build();
 
-        response.addCookie(cookie);
+        response.addHeader("Set-Cookie", cookie.toString());
 
         clearAuthenticationAttributes(request, response);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/practice/OAuth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/practice/OAuth2/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -10,6 +10,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
@@ -33,18 +34,29 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
-        String targetUrl = determineTargetUrl(request, response, authentication);
+        String targetUrl = determineTargetUrl(request, response);
 
         if (response.isCommitted()) {
             logger.debug("Response has already been committed. Unable to redirect to " + targetUrl);
             return;
         }
 
+        String token = tokenProvider.createToken(authentication);
+
+        // HttpOnly Cookie 생성
+        Cookie cookie = new Cookie("access_token", token);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true); // JS 접근 불가 (XSS 방지)
+        // cookie.setSecure(true);   // HTTPS 전용 (배포 환경 필수)
+        cookie.setMaxAge((int) appProperties.getAuth().getTokenExpirationMsec() / 1000); // 토큰 유효시간과 쿠키 유효시간 일치
+
+        response.addCookie(cookie);
+
         clearAuthenticationAttributes(request, response);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
     }
 
-    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response, Authentication authentication) {
+    protected String determineTargetUrl(HttpServletRequest request, HttpServletResponse response) {
         Optional<String> redirectUri = CookieUtils.getCookie(request, REDIRECT_URI_PARAM_COOKIE_NAME)
                 .map(Cookie::getValue);
 
@@ -54,10 +66,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
         String targetUrl = redirectUri.orElse(getDefaultTargetUrl());
 
-        String token = tokenProvider.createToken(authentication);
-
         return UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("token", token)
                 .build().toUriString();
     }
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #3 
## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
- 토큰 쿼리스트링 응답방식에서 HttpOnly 쿠키 응답 방식으로 변환
<img width="835" height="367" alt="image" src="https://github.com/user-attachments/assets/f3b00139-79f4-47bf-9375-c43e7a09539b" />

## ✨참고 사항 
- 한줄 요약 : 프런트에서 토큰 관련 작업 아무것도 안해도됨

<!-- 작업내용 사진을 올려주세요 (postman api test결과 등) -->
1. 발급 (Backend): 로그인 성공 시, 백엔드는 JWT를 Body가 아닌 **Response Header(`Set-Cookie`)**에 담아 보냄, 이때 `HttpOnly` 스티커를 붙여서 "JS 접근 금지"를 선언 (XSS 방지), samesite 설정으로 CSRF 방지
2. 저장 (Browser): 브라우저는 헤더를 보자마자 쿠키를 내부 저장소에 자동 저장. 프런트엔드 코드는 이 쿠키를 볼 수 없음 (테스트용으로 토큰을 확인하려면 직접 브라우저의 개발자 도구에서 확인 가능)
3. 사용 (Browser): 프런트엔드가 API 요청을 보낼 때(`withCredentials: true`), 브라우저는 알아서 쿠키를 꺼내 요청 헤더에 붙여 전송


