### PR TITLE
Feature/#12 WebSocket/STOMP 통신 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'mysql:mysql-connector-java:8.0.26'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
@@ -1,0 +1,4 @@
+package com.practice.OAuth2.domain.plan.controller;
+
+public class PlanController {
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanWebSocketController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanWebSocketController.java
@@ -1,0 +1,14 @@
+package com.practice.OAuth2.domain.plan.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Controller;
+
+@Controller
+@RequiredArgsConstructor
+public class PlanWebSocketController {
+    // 메시지 브로커로 메시지 전달하는 핵심 도구
+    private final SimpMessagingTemplate template;
+
+
+}

--- a/src/main/java/com/practice/OAuth2/global/config/WebSocketConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/WebSocketConfig.java
@@ -1,0 +1,28 @@
+package com.practice.OAuth2.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.simp.config.MessageBrokerRegistry;
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
+
+@Configuration
+@EnableWebSocketMessageBroker
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
+    @Override
+    public void registerStompEndpoints(StompEndpointRegistry registry) {
+        // 클라이언트가 서버에 핸드셰이크할 엔드포인트 (웹소켓 연결 시작 URL)
+        registry.addEndpoint("/ws")
+                .setAllowedOriginPatterns("*")
+                .withSockJS();
+    }
+
+    @Override
+    public void configureMessageBroker(MessageBrokerRegistry registry) {
+        // 클라이언트가 서버 구독하고, 서버가 클라이언트에게 메시지 발행하는 Prefix
+        registry.enableSimpleBroker("/topic");
+
+        // 클라이언트에서 서버로 메시지 보내는 Prefix (@MessageMapping 핸들러로 라우팅)
+        registry.setApplicationDestinationPrefixes("/app");
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #12 
## 💥작업 내용
- global/config/WebSocketConfig.java 구현 (엔드포인트, 통신 접두사 설정)
- domain/plan/controller에 PlanController, PlanWebSocketController 생성 (내부 내용은 거의 없음) 
## ✨참고 사항 
- RestAPI할 때 @RequestMapping 하듯이 웹소켓 컨트롤러에는 @MessageMapping 사용하는 것 같음


