### PR TITLE
Fix : 쿠기 생성 후 반환 시 lax해제, 전역 예외처리 추가

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/controller/AuthController.java
@@ -42,11 +42,6 @@ import java.util.Collections;
 @RequiredArgsConstructor
 public class AuthController {  // 우리 서비스 자체 로그인 시스템 API ( 리프레쉬 관련 재발급 코드, 로그아웃 코드 포함)
 
-    private final AuthenticationManager authenticationManager;
-
-    private final UserRepository userRepository;
-
-    private final PasswordEncoder passwordEncoder;
 
     private final TokenProvider tokenProvider;
 
@@ -135,7 +130,7 @@ public class AuthController {  // 우리 서비스 자체 로그인 시스템 AP
                 .httpOnly(true)
                 .secure(true)
                 .maxAge(accessAge)
-//                .sameSite("Lax")
+                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
                 .build();
 
         // Refresh Token 쿠키 설정 (14일), 재발급 요청에만 브라우저가 보내게함
@@ -144,7 +139,7 @@ public class AuthController {  // 우리 서비스 자체 로그인 시스템 AP
                 .httpOnly(true)
                 .secure(true)
                 .maxAge(refreshAge)
-//                .sameSite("Lax")
+                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
                 .build();
 
         response.addHeader("Set-Cookie", accessCookie.toString());

--- a/src/main/java/com/practice/OAuth2/domain/auth/controller/AuthController.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/controller/AuthController.java
@@ -1,5 +1,7 @@
 package com.practice.OAuth2.domain.auth.controller;
 
+import com.practice.OAuth2.domain.auth.dto.TokenResponse;
+import com.practice.OAuth2.domain.auth.service.AuthService;
 import com.practice.OAuth2.global.config.AppProperties;
 import com.practice.OAuth2.global.exception.BadRequestException;
 import com.practice.OAuth2.domain.user.entity.AuthProvider;
@@ -14,6 +16,7 @@ import com.practice.OAuth2.domain.user.repository.UserRepository;
 import com.practice.OAuth2.global.security.TokenProvider;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import com.practice.OAuth2.global.util.CookieUtils;
+import com.practice.OAuth2.global.util.TokenCookieManager;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
@@ -40,13 +43,10 @@ import java.util.Collections;
 @RestController
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
-public class AuthController {  // 우리 서비스 자체 로그인 시스템 API ( 리프레쉬 관련 재발급 코드, 로그아웃 코드 포함)
+public class AuthController {
 
-
-    private final TokenProvider tokenProvider;
-
-    private final RefreshTokenRepository refreshTokenRepository;
-
+    private final AuthService authService;
+    private final TokenCookieManager tokenCookieManager;
     private final AppProperties appProperties;
     
     // 소셜 로그인 유저라도 Access Token(30분)이 만료되면 프런트엔드가 이 API를 호출해서 연명 치료를 해야함
@@ -57,48 +57,16 @@ public class AuthController {  // 우리 서비스 자체 로그인 시스템 AP
                 .map(Cookie::getValue)
                 .orElse(null);
 
-        // 리프레시 토큰 존재 여부
-        if (refreshToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("리프레시 토큰이 없습니다.");
-        }
+        // 서비스단 예외 발생 시 GlobalHandler 로 처리
+        TokenResponse tokenResponse = authService.reissue(refreshToken);
 
-        // 리프레시토큰 유효성 검사 체크
-        if (!tokenProvider.validateToken(refreshToken)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("유효하지 않은 리프레시 토큰입니다.");
-        }
-
-        // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교
-        String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
-        
-        // 속도를 위해 PK (id) 사용
-        RefreshToken redisToken = refreshTokenRepository.findById(userId).orElse(null);
-
-        if (redisToken == null) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("리프레시 토큰의 유효기간이 만료되었습니다.");
-        }
-
-        if (!redisToken.getToken().equals(refreshToken)) {
-            return ResponseEntity.status(HttpStatus.UNAUTHORIZED).body("잘못된 리프레시 토큰입니다.");
-        }
-
-        // 새 토큰 생성을 위한 Authentication 객체 생성 (ID만 있으면 됨)
-        // TokenProvider는 토큰을 만들 때 Authentication 안에 있는 UserPrincipal을 꺼내고, 그 안의 id를 써서 토큰을 만들도록 되어있음
-        UserDetails principal = UserPrincipal.create(Long.parseLong(userId));
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
-
-        // 새 토큰 발급 (RTR: Refresh Token도 새로 발급)
-        String newAccessToken = tokenProvider.createToken(authentication);
-        String newRefreshToken = tokenProvider.createRefreshToken(authentication);
-
-        // 6. Redis 업데이트
-        refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
-
-        // 7. 쿠키 갱신
+        // 쿠키 시간 설정
         long accessTokenExpiry = appProperties.getAuth().getTokenExpirationMsec() / 1000;
         long refreshTokenExpiry = 1209600; // 14일
 
         // 응답 헤더에 쿠키를 Set-Cookie (새로 발급받은 엑세스,리프레시 토큰)
-        setTokenCookies(response, newAccessToken, newRefreshToken, accessTokenExpiry, refreshTokenExpiry);
+        tokenCookieManager.addTokenCookies(response, tokenResponse.getAccessToken(),
+                tokenResponse.getRefreshToken(), accessTokenExpiry, refreshTokenExpiry);
 
         return ResponseEntity.status(HttpStatus.OK).body("토큰 재발급 완료.");
     }
@@ -106,43 +74,15 @@ public class AuthController {  // 우리 서비스 자체 로그인 시스템 AP
 
     @PostMapping("/logout")
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        String refreshToken = CookieUtils.getCookie(request, "refresh_token")
+                .map(Cookie::getValue)
+                .orElse(null);
 
+        authService.logout(refreshToken);
 
-        // 브라우저가 보낸 쿠키 중 리프레시 토큰 조회
-        String refreshToken = CookieUtils.getCookie(request, "refresh_token").map(Cookie::getValue).orElse(null);
+        tokenCookieManager.deleteTokenCookies(response);
 
-        // 리프레시 토큰이 있고 이게 유효하다면 -> 레디스캐시 Repository의 리프레시 토큰 삭제
-        if (refreshToken != null && tokenProvider.validateToken(refreshToken)) {
-            String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
-            refreshTokenRepository.deleteById(userId);
-        }
-
-        // 응답 헤더에 쿠키를 Set-Cookie (Max-Age = 0)
-        setTokenCookies(response, "", "", 0, 0);
-
-        return new ResponseEntity<>("로그아웃 되었습니다", HttpStatus.OK);
+        return ResponseEntity.ok("로그아웃 되었습니다");
     }
 
-    // 클라이언트에게 헤더에 응답쿠키를 설정하여 응답하는 메서드 -> 브라우저가 관리할 쿠키 설정
-    private void setTokenCookies(HttpServletResponse response, String accessToken, String refreshToken, long accessAge, long refreshAge) {
-        ResponseCookie accessCookie = ResponseCookie.from("access_token", accessToken)
-                .path("/")
-                .httpOnly(true)
-                .secure(true)
-                .maxAge(accessAge)
-                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
-                .build();
-
-        // Refresh Token 쿠키 설정 (14일), 재발급 요청에만 브라우저가 보내게함
-        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
-                .path("/api/auth/reissue")
-                .httpOnly(true)
-                .secure(true)
-                .maxAge(refreshAge)
-                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
-                .build();
-
-        response.addHeader("Set-Cookie", accessCookie.toString());
-        response.addHeader("Set-Cookie", refreshCookie.toString());
-    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/auth/dto/TokenResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/dto/TokenResponse.java
@@ -1,0 +1,14 @@
+package com.practice.OAuth2.domain.auth.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor @NoArgsConstructor
+@Builder
+public class TokenResponse {
+    private String accessToken;
+    private String refreshToken;
+}

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -1,0 +1,83 @@
+package com.practice.OAuth2.domain.auth.service;
+
+import com.practice.OAuth2.domain.auth.dto.TokenResponse;
+import com.practice.OAuth2.domain.auth.entity.RefreshToken;
+import com.practice.OAuth2.domain.auth.repository.RefreshTokenRepository;
+import com.practice.OAuth2.global.exception.BadRequestException;
+import com.practice.OAuth2.global.security.TokenProvider;
+import com.practice.OAuth2.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final TokenProvider tokenProvider;
+
+    @Transactional
+    public TokenResponse reissue(String refreshToken) {
+        if (refreshToken == null) {
+            throw new BadRequestException("리프레시 토큰이 없습니다.");
+        }
+
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교
+        String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
+        // 속도를 위해 PK (id) 사용
+        RefreshToken redisToken = refreshTokenRepository.findById(userId).orElse(null);
+
+        if (redisToken == null) {
+            // Redis 에 리프레시토큰 유효기간 만료
+            throw new BadRequestException("만료된 리프레시 토큰입니다.");
+        } else if (!redisToken.getToken().equals(refreshToken)) {
+            // 사용자의 브라우저 쿠키의 리프레시 토큰이 Redis 와 다름 (브라우저 종료 후 새 브라우저로 접속 시)
+            throw new BadRequestException("리프레시 토큰이 만료되었습니다.");
+        }
+
+        // 재발급 로직
+
+        // 새 토큰 생성을 위한 Authentication 객체 생성 (ID만 있으면 됨)
+        // TokenProvider는 토큰을 만들 때 Authentication 안에 있는 UserPrincipal을 꺼내고, 그 안의 id를 써서 토큰을 만들도록 되어있음
+        UserDetails principal = UserPrincipal.create(Long.parseLong(userId));
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
+
+        // 새 토큰 발급 (RTR: Refresh Token도 새로 발급)
+        String newAccessToken = tokenProvider.createToken(authentication);
+        String newRefreshToken = tokenProvider.createRefreshToken(authentication);
+
+        // 5. Redis 업데이트
+        refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
+
+        return TokenResponse.builder()
+                .accessToken(newAccessToken)
+                .refreshToken(newRefreshToken)
+                .build();
+    }
+
+    @Transactional
+    public void logout(String refreshToken) {
+
+        if (refreshToken == null) {
+            throw new BadRequestException("리프레시 토큰이 없습니다.");
+        }
+
+        if (!tokenProvider.validateToken(refreshToken)) {
+            throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
+        }
+
+        String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
+        refreshTokenRepository.deleteById(userId);
+
+    }
+}

--- a/src/main/java/com/practice/OAuth2/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/practice/OAuth2/global/exception/GlobalExceptionHandler.java
@@ -1,0 +1,19 @@
+package com.practice.OAuth2.global.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+
+    @ExceptionHandler(BadRequestException.class)
+    public ResponseEntity<String> handleBadRequestException(BadRequestException e) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(e.getMessage());
+    }
+
+
+}

--- a/src/main/java/com/practice/OAuth2/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/practice/OAuth2/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -7,6 +7,7 @@ import com.practice.OAuth2.domain.auth.repository.RefreshTokenRepository;
 import com.practice.OAuth2.global.security.TokenProvider;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import com.practice.OAuth2.global.util.CookieUtils;
+import com.practice.OAuth2.global.util.TokenCookieManager;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
@@ -36,6 +37,8 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
 
     private final RefreshTokenRepository refreshTokenRepository; // Redis Repository 추가
 
+    private final TokenCookieManager tokenCookieManager;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response, Authentication authentication) throws IOException, ServletException {
         String targetUrl = determineTargetUrl(request, response);
@@ -46,7 +49,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         }
 
         // 엑세스 토큰 생성
-        String token = tokenProvider.createToken(authentication);
+        String accessToken = tokenProvider.createToken(authentication);
         
         // 리프레시 토큰 생성
         String refreshToken = tokenProvider.createRefreshToken(authentication);
@@ -56,25 +59,13 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
         UserPrincipal userPrincipal = (UserPrincipal) authentication.getPrincipal(); // Spring Security가 관리하는 현재 로그인한 사용자 정보(Object)를 우리가 만든 커스텀 객체(UserPrincipal)로 변환
         refreshTokenRepository.save(new RefreshToken(Long.toString(userPrincipal.getId()), refreshToken));
 
-        ResponseCookie cookie = ResponseCookie.from("access_token", token)
-                .path("/")
-                .httpOnly(true)
-                .secure(true) // HTTPS 배포
-                .maxAge(appProperties.getAuth().getTokenExpirationMsec() / 1000)
-                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
-                .build();
+        // 쿠키 시간 설정
+        long accessTokenExpiry = appProperties.getAuth().getTokenExpirationMsec() / 1000;
+        long refreshTokenExpiry = 1209600; // 14일
 
-        // Refresh Token 쿠키 설정 (14일), 재발급 요청에만 브라우저가 보내게함
-        ResponseCookie refreshCookie = ResponseCookie.from("refresh_token", refreshToken)
-                .path("/api/auth/reissue")
-                .httpOnly(true)
-                .secure(true)
-                .maxAge(1209600) // 14일 (초 단위, Redis TTL 따름)
-                .sameSite("None")
-                .build();
-
-        response.addHeader("Set-Cookie", cookie.toString());
-        response.addHeader("Set-Cookie", refreshCookie.toString());
+        // 응답 헤더에 쿠키를 Set-Cookie (새로 발급받은 엑세스,리프레시 토큰)
+        tokenCookieManager.addTokenCookies(response, accessToken,
+                refreshToken, accessTokenExpiry, refreshTokenExpiry);
 
         clearAuthenticationAttributes(request, response);
         getRedirectStrategy().sendRedirect(request, response, targetUrl);

--- a/src/main/java/com/practice/OAuth2/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/practice/OAuth2/global/security/oauth2/OAuth2AuthenticationSuccessHandler.java
@@ -61,7 +61,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .httpOnly(true)
                 .secure(true) // HTTPS 배포
                 .maxAge(appProperties.getAuth().getTokenExpirationMsec() / 1000)
-//                .sameSite("Lax") // 명시적으로 Lax 설정 (CSRF 방어)
+                .sameSite("None") // 명시적으로 Lax 설정 (CSRF 방어) -> 개발 단계에서는 일단 프런트 배포 이전이므로 같은 도메인만 허용 해제
                 .build();
 
         // Refresh Token 쿠키 설정 (14일), 재발급 요청에만 브라우저가 보내게함
@@ -70,7 +70,7 @@ public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationS
                 .httpOnly(true)
                 .secure(true)
                 .maxAge(1209600) // 14일 (초 단위, Redis TTL 따름)
-//                .sameSite("Lax")
+                .sameSite("None")
                 .build();
 
         response.addHeader("Set-Cookie", cookie.toString());

--- a/src/main/java/com/practice/OAuth2/global/util/TokenCookieManager.java
+++ b/src/main/java/com/practice/OAuth2/global/util/TokenCookieManager.java
@@ -1,0 +1,59 @@
+package com.practice.OAuth2.global.util;
+
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenCookieManager {
+
+    private static final String ACCESS_TOKEN_NAME = "access_token";
+    private static final String REFRESH_TOKEN_NAME = "refresh_token";
+    private static final String REFRESH_TOKEN_PATH = "/api/auth/reissue";
+
+    // 토큰 쿠키 굽기 (로그인, 재발급 용)
+    public void addTokenCookies(HttpServletResponse response, String accessToken, String refreshToken, long accessAge, long refreshAge) {
+        // Access Token
+        ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN_NAME, accessToken)
+                .path("/")
+                .httpOnly(true)
+                .secure(true) // HTTPS 필수
+                .maxAge(accessAge)
+                .sameSite("None") // 프런트 배포 이전에 테스트용으로 lax 해제
+                .build();
+
+        // Refresh Token
+        ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN_NAME, refreshToken)
+                .path(REFRESH_TOKEN_PATH) // 재발급 경로에만 전송
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(refreshAge) // 브라우저 꺼도 유지됨 (Persistent Cookie)
+                .sameSite("None")
+                .build();
+
+        response.addHeader("Set-Cookie", accessCookie.toString());
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+    }
+
+    // 토큰 쿠키 삭제 (로그아웃 용 : maxAge 가 0 인채로 Set-Cookie)
+    public void deleteTokenCookies(HttpServletResponse response) {
+        ResponseCookie accessCookie = ResponseCookie.from(ACCESS_TOKEN_NAME, "")
+                .path("/")
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+
+        ResponseCookie refreshCookie = ResponseCookie.from(REFRESH_TOKEN_NAME, "")
+                .path(REFRESH_TOKEN_PATH)
+                .httpOnly(true)
+                .secure(true)
+                .maxAge(0)
+                .sameSite("None")
+                .build();
+
+        response.addHeader("Set-Cookie", accessCookie.toString());
+        response.addHeader("Set-Cookie", refreshCookie.toString());
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #35 
## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
<!-- 작업내용 사진을 올리면 더 좋습니다 (postman api test결과 등) -->
- 전역 예외처리 핸들러 (GlobalExceptionHandler) 생성 -> try-catch문 필요 없이 serveice에서 컨트롤러로 예외 던지면 GlobalExceptionHandler 가 컨트롤러에게 온 예외를 처리 (@RestControllerAdvice)
- 아직 프런트엔드 배포 전이므로 테스트용도로 쿠키에 lax 해제 명시
## ✨참고 사항 
- 전역 예외처리 핸들러 사용을 위한 커스텀예외클래스 필요


