### PR TITLE
Feature : user 도메인 구현

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/user/controller/UserController.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/controller/UserController.java
@@ -1,5 +1,6 @@
 package com.practice.OAuth2.domain.user.controller;
 
+import com.practice.OAuth2.domain.user.dto.UserInfoRequest;
 import com.practice.OAuth2.domain.user.dto.UserInfoResponse;
 import com.practice.OAuth2.domain.user.service.UserInfoService;
 import com.practice.OAuth2.global.exception.ResourceNotFoundException;
@@ -11,7 +12,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,10 +26,26 @@ public class UserController {
 
     private final UserInfoService userInfoService;
 
+    // 내 정보 조회
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getCurrentUser(@CurrentUser UserPrincipal userPrincipal) {
 
-        return ResponseEntity.status(HttpStatus.OK).
-                body(userInfoService.getCurrentUser(userPrincipal));
+        return ResponseEntity.ok(userInfoService.getCurrentUser(userPrincipal));
+    }
+
+    // 프로필 수정
+    @PatchMapping("/me")
+    public ResponseEntity<UserInfoResponse> updateUserProfile(@CurrentUser UserPrincipal userPrincipal,
+            @RequestBody UserInfoRequest.updateUserProfile req) {
+
+        return ResponseEntity.ok(userInfoService.updateUserProfile(userPrincipal, req));
+    }
+
+    // 탈퇴
+    @DeleteMapping("/me")
+    public ResponseEntity<String> withdraw(@CurrentUser UserPrincipal userPrincipal) {
+
+        userInfoService.withdraw(userPrincipal);
+        return ResponseEntity.ok("회원 탈퇴가 완료되었습니다.");
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/controller/UserController.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/controller/UserController.java
@@ -33,7 +33,7 @@ public class UserController {
         return ResponseEntity.ok(userInfoService.getCurrentUser(userPrincipal));
     }
 
-    // 프로필 수정
+    // 닉네임 수정
     @PatchMapping("/me")
     public ResponseEntity<UserInfoResponse> updateUserProfile(@CurrentUser UserPrincipal userPrincipal,
             @RequestBody UserInfoRequest.updateUserProfile req) {

--- a/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoRequest.java
@@ -9,6 +9,5 @@ public class UserInfoRequest {
     @NoArgsConstructor
     public static class updateUserProfile{
         private String nickname;
-        private String profileImageUrl;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoRequest.java
@@ -1,0 +1,14 @@
+package com.practice.OAuth2.domain.user.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+public class UserInfoRequest {
+
+    @Getter
+    @NoArgsConstructor
+    public static class updateUserProfile{
+        private String nickname;
+        private String profileImageUrl;
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/dto/UserInfoResponse.java
@@ -2,6 +2,7 @@ package com.practice.OAuth2.domain.user.dto;
 
 import com.practice.OAuth2.domain.user.entity.AuthProvider;
 import com.practice.OAuth2.domain.user.entity.User;
+import com.practice.OAuth2.global.config.AppProperties.Auth;
 import jakarta.persistence.Column;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -22,7 +23,7 @@ public class UserInfoResponse {
     private String name;
     private String nickname;
     private String profileImageUrl;
-    private LocalDateTime deletedAt;
+    private AuthProvider provider;
 
     public static UserInfoResponse from(User user) {
         return UserInfoResponse.builder()
@@ -31,7 +32,7 @@ public class UserInfoResponse {
                 .name(user.getName())
                 .nickname(user.getNickname())
                 .profileImageUrl(user.getProfileImageUrl())
-                .deletedAt(user.getDeletedAt())
+                .provider(user.getProvider())
                 .build();
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
@@ -45,4 +45,8 @@ public class User extends BaseEntity{
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    public void updateUserProfile(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
@@ -54,11 +54,10 @@ public class User extends BaseEntity{
     private LocalDateTime deletedAt;
 
     @Builder
-    public User(String email, String name, String nickname, String password, AuthProvider provider, String providerId, String profileImageUrl) {
+    public User(String email, String name, String nickname, AuthProvider provider, String providerId, String profileImageUrl) {
         this.email = email;
         this.name = name;
         this.nickname = nickname;
-        this.password = password;
         this.provider = provider;
         this.providerId = providerId;
         this.profileImageUrl = profileImageUrl;

--- a/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/entity/User.java
@@ -7,10 +7,17 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
 
 import lombok.*;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.Where;
 
 
 @Entity
 @Getter @Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@SQLDelete(sql = "UPDATE users SET deleted_at = NOW() WHERE user_id = ?")
+@Where(clause = "deleted_at IS NULL")
 @Table(name = "users", uniqueConstraints = {@UniqueConstraint(columnNames = "email")})
 public class User extends BaseEntity{
     @Id
@@ -39,14 +46,26 @@ public class User extends BaseEntity{
     @Column(name = "provider_id")
     private String providerId;
 
-//    @Column(nullable = false)
-//    private Boolean emailVerified = false;
+    @Builder.Default
+    @Column(nullable = false)
+    private Boolean emailVerified = false;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
-    public void updateUserProfile(String nickname, String profileImageUrl) {
+    @Builder
+    public User(String email, String name, String nickname, String password, AuthProvider provider, String providerId, String profileImageUrl) {
+        this.email = email;
+        this.name = name;
         this.nickname = nickname;
+        this.password = password;
+        this.provider = provider;
+        this.providerId = providerId;
         this.profileImageUrl = profileImageUrl;
+        this.emailVerified = false;
+    }
+
+    public void updateUserProfile(String nickname) {
+        this.nickname = nickname;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
@@ -15,4 +15,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Boolean existsByEmail(String email);
 
+    // 닉네임 중복 체크 등에 사용
+    Boolean existsByNickname(String nickname);
+
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
@@ -10,6 +10,7 @@ import java.util.Optional;
 @Repository
 public interface UserRepository extends JpaRepository<User, Long> {
 
+    // 로그인 시 필요
     Optional<User> findByEmail(String email);
 
     Boolean existsByEmail(String email);

--- a/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/repository/UserRepository.java
@@ -2,9 +2,12 @@ package com.practice.OAuth2.domain.user.repository;
 
 import com.practice.OAuth2.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 
 @Repository
@@ -17,5 +20,10 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     // 닉네임 중복 체크 등에 사용
     Boolean existsByNickname(String nickname);
+
+    @Transactional
+    @Modifying
+    @Query(value = "UPDATE users SET deleted_at = NULL WHERE email = :email", nativeQuery = true)
+    int restoreUser(String email);
 
 }

--- a/src/main/java/com/practice/OAuth2/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/service/UserInfoService.java
@@ -25,12 +25,12 @@ public class UserInfoService {
         return UserInfoResponse.from(user);
     }
 
-    // 프로필 수정
+    // 닉네임 수정
     public UserInfoResponse updateUserProfile(UserPrincipal userPrincipal, UserInfoRequest.updateUserProfile req  ){
         User user = userRepository.findById(userPrincipal.getId())
                 .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
 
-        user.updateUserProfile(req.getNickname(), req.getProfileImageUrl()  );
+        user.updateUserProfile(req.getNickname() );
         return UserInfoResponse.from(user);
     }
 

--- a/src/main/java/com/practice/OAuth2/domain/user/service/UserInfoService.java
+++ b/src/main/java/com/practice/OAuth2/domain/user/service/UserInfoService.java
@@ -1,5 +1,6 @@
 package com.practice.OAuth2.domain.user.service;
 
+import com.practice.OAuth2.domain.user.dto.UserInfoRequest;
 import com.practice.OAuth2.domain.user.dto.UserInfoResponse;
 import com.practice.OAuth2.domain.user.entity.User;
 import com.practice.OAuth2.domain.user.repository.UserRepository;
@@ -11,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class UserInfoService {
 
     private final UserRepository userRepository;
@@ -23,5 +25,20 @@ public class UserInfoService {
         return UserInfoResponse.from(user);
     }
 
+    // 프로필 수정
+    public UserInfoResponse updateUserProfile(UserPrincipal userPrincipal, UserInfoRequest.updateUserProfile req  ){
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
 
+        user.updateUserProfile(req.getNickname(), req.getProfileImageUrl()  );
+        return UserInfoResponse.from(user);
+    }
+
+    // 회원 탈퇴
+    public void withdraw(UserPrincipal userPrincipal){
+        User user = userRepository.findById(userPrincipal.getId())
+                .orElseThrow(() -> new ResourceNotFoundException("User", "id", userPrincipal.getId()));
+
+        userRepository.delete(user);
+    }
 }

--- a/src/main/java/com/practice/OAuth2/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/practice/OAuth2/global/security/oauth2/CustomOAuth2UserService.java
@@ -7,6 +7,8 @@ import com.practice.OAuth2.domain.user.repository.UserRepository;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import com.practice.OAuth2.global.security.oauth2.user.OAuth2UserInfo;
 import com.practice.OAuth2.global.security.oauth2.user.OAuth2UserInfoFactory;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.Query;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.authentication.InternalAuthenticationServiceException;
 import org.springframework.security.core.AuthenticationException;
@@ -57,10 +59,32 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
             }
             user = updateExistingUser(user, oAuth2UserInfo);
         } else {
-            user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+            // (추가) 탈퇴한 유저인지 확인
+            user = restoreIfDeleted(oAuth2UserInfo.getEmail());
+
+            if (user != null) {
+                // 탈퇴한 유저 복구 후 업데이트
+                user = updateExistingUser(user, oAuth2UserInfo);
+            } else {
+                // 아예 없는 유저 -> 신규 가입
+                user = registerNewUser(oAuth2UserRequest, oAuth2UserInfo);
+            }
         }
 
         return UserPrincipal.create(user, oAuth2User.getAttributes());
+    }
+
+    // (추가) 탈퇴한 유저 복구 메서드
+    private User restoreIfDeleted(String email) {
+        // 복구 쿼리 실행 (업데이트된 행의 개수 반환)
+        int updatedCount = userRepository.restoreUser(email);
+
+        if (updatedCount > 0) {
+            // 복구됐으면(1건 이상 업데이트) 해당 유저 정보를 조회해서 반환
+            // 이제 deleted_at이 NULL이 되었으므로 findByEmail로 조회가 가능
+            return userRepository.findByEmail(email).orElse(null);
+        }
+        return null; // 복구할 대상이 x-> 신규 가입 필요
     }
 
     private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {

--- a/src/main/java/com/practice/OAuth2/global/security/oauth2/CustomOAuth2UserService.java
+++ b/src/main/java/com/practice/OAuth2/global/security/oauth2/CustomOAuth2UserService.java
@@ -87,14 +87,18 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
         return null; // 복구할 대상이 x-> 신규 가입 필요
     }
 
+    // 빌더패턴으로 수정
     private User registerNewUser(OAuth2UserRequest oAuth2UserRequest, OAuth2UserInfo oAuth2UserInfo) {
-        User user = new User();
+        AuthProvider provider = AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId());
 
-        user.setProvider(AuthProvider.valueOf(oAuth2UserRequest.getClientRegistration().getRegistrationId()));
-        user.setProviderId(oAuth2UserInfo.getId());
-        user.setName(oAuth2UserInfo.getName());
-        user.setEmail(oAuth2UserInfo.getEmail());
-        user.setProfileImageUrl(oAuth2UserInfo.getImageUrl());
+        User user = User.builder()
+                .provider(provider)
+                .providerId(oAuth2UserInfo.getId())
+                .name(oAuth2UserInfo.getName())
+                .email(oAuth2UserInfo.getEmail())
+                .profileImageUrl(oAuth2UserInfo.getImageUrl())
+                .build();
+
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #38
## 💥작업 내용
- user 도메인 검토
- 닉네임 수정 기능 구현
- 회원 탈퇴 기능 구현
- 탈퇴 후 재로그인시 프로필 복구 기능 구현
- CustomOAuth2UserService 빌더 패턴으로 수정 
- user 닉네임 수정 테스트(성공)
- user 탈퇴_삭제 테스트(성공)
- user 재로그인 테스트(복구 및 로그인 성공)
## ✨참고 사항 
- [Trouble Shooting] 탈퇴시 영구삭제되는 현상(deleted_at이 있음에도)
  - Hard Delete -> Soft Delete
- [Trouble Shooting] 탈퇴 후 재로그인시 Soft Delete 유저 중복 가입 에러
  - 이메일(uk)확인 ->(신규 아닐 경우) 복구 쿼리 실행 -> repository에 restoreUser메서드 구현


