### PR TITLE
Modify : plan 도메인 엔티티 수정

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/Plan.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/Plan.java
@@ -13,6 +13,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.UUID;
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -20,7 +23,7 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Table(name = "plans")
 @SQLDelete(sql = "UPDATE plans SET deleted_at = NOW() WHERE plan_id = ?")
 @Where(clause = "deleted_at IS NULL")
@@ -29,10 +32,6 @@ public class Plan extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "plan_id")
     private Long planId;
-
-    @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "owner_id", nullable = false)
-    private User owner;
 
     @Column(nullable = false, length = 100)
     private String title;
@@ -43,15 +42,23 @@ public class Plan extends BaseEntity {
     @Column(name = "end_date", nullable = false)
     private LocalDate endDate;
 
-    @Column(length = 50)
-    private String region;
-
     @Column(name = "plan_image_url")
     private String planImageUrl;
 
-    @Column(name = "is_share", columnDefinition = "tinyint(1) DEFAULT 0")
-    private Boolean isShare;
+    // 추가: STOMP 방 입장/초대용 코드 (랜덤 UUID)
+    @Column(name = "invite_code", nullable = false, unique = true)
+    private String inviteCode;
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    @Builder
+    public Plan(String title, LocalDate startDate, LocalDate endDate, String region, String planImageUrl) {
+        this.title = title;
+        this.startDate = startDate;
+        this.endDate = endDate;
+        this.planImageUrl = planImageUrl;
+        // 생성 시 초대코드 자동 발급
+        this.inviteCode = UUID.randomUUID().toString();
+    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/PlanMember.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/PlanMember.java
@@ -14,6 +14,7 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import jakarta.persistence.UniqueConstraint;
 import java.time.LocalDateTime;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.data.annotation.CreatedDate;
@@ -40,10 +41,23 @@ public class PlanMember extends BaseEntity {
     @JoinColumn(name = "user_id", nullable = false)
     private User user;
 
-    @Column(length = 20)
-    private String role;
+    // 추가: 방 나가기 기능 (NULL이면 참여 중)
+    @Column(name = "left_at")
+    private LocalDateTime leftAt;
 
-    @CreatedDate
-    @Column(name = "created_at", updatable = false)
-    private LocalDateTime createdAt;
+    @Builder
+    public PlanMember(Plan plan, User user) {
+        this.plan = plan;
+        this.user = user;
+    }
+
+    //  방 나가기 (Soft Delete와 유사)
+    public void exitPlan() {
+        this.leftAt = LocalDateTime.now();
+    }
+
+    //  재입장
+    public void reJoin() {
+        this.leftAt = null;
+    }
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #46
## 💥작업 내용
- plan 엔티티 수정
  - region 삭제
  - owner 삭제
  - isShare 삭제
  - inviteCode 추가
- plan members 엔티티 수정
  - role 삭제
  - leftAt 추가(퇴장 시간 -> 현재 방에 남아있는지 체크)
## ✨참고 사항 
- db 수정해야함(ERD)
- 아래 사항에 따른 수정
  1. role [plan_members] 삭제
  2. users, plans 1대 다 관계 삭제 → users-plan_members-plans 로 수정해서 중복성 제거
  3. 나가기 기능(카카오톡 단체 채팅방 나가기 기능 처럼)"`


