### PR TITLE
Feature : plan 도메인 구현 (stomp 이용)

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
@@ -1,0 +1,25 @@
+package com.practice.OAuth2.domain.attraction.controller;
+
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.service.AttractionService;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/attractions")
+public class AttractionController {
+    private final AttractionService attractionService;
+
+    // 장소 검색
+    @GetMapping
+    public ResponseEntity<List<AttractionResponse>> search(@RequestParam String keyword) {
+        List<AttractionResponse> results = attractionService.searchAttractions(keyword);
+        return ResponseEntity.ok(results);
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse.java
@@ -1,0 +1,31 @@
+package com.practice.OAuth2.domain.attraction.dto;
+
+import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import lombok.Getter;
+
+@Getter
+public class AttractionResponse {
+    private Integer attractionId;
+    private String title;         // 장소명
+    private String address;       // 주소 (addr1)
+    private String imageUrl;      // 썸네일 이미지 (firstImage1)
+    private Double latitude;      // BigDecimal -> Double 변환
+    private Double longitude;
+
+    public AttractionResponse(Attraction attraction) {
+        this.attractionId = attraction.getAttrId();
+        this.title = attraction.getTitle();
+        this.address = attraction.getAddr1(); // 주로 addr1이 도로명/지번 주소
+
+        // 이미지가 없을 경우 firstImage2를 쓸 수도 있지만, 일단 1번을 메인으로 사용
+        this.imageUrl = attraction.getFirstImage1();
+
+        // BigDecimal을 프론트에서 쓰기 편한 Double로 변환 (null 체크 포함)
+        if (attraction.getLatitude() != null) {
+            this.latitude = attraction.getLatitude().doubleValue();
+        }
+        if (attraction.getLongitude() != null) {
+            this.longitude = attraction.getLongitude().doubleValue();
+        }
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/repository/AttractionRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/repository/AttractionRepository.java
@@ -1,0 +1,11 @@
+package com.practice.OAuth2.domain.attraction.repository;
+
+import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface AttractionRepository extends JpaRepository<Attraction, Integer> {
+
+    // 키워드 검색
+    List<Attraction> findByTitleContaining(String keyword);
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
@@ -1,0 +1,27 @@
+package com.practice.OAuth2.domain.attraction.service;
+
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.repository.AttractionRepository;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class AttractionService {
+    private final AttractionRepository attractionRepository;
+
+    public List<AttractionResponse> searchAttractions(String keyword) {
+        if (keyword == null || keyword.trim().isEmpty()) {
+            return List.of(); // 검색어 없으면 빈 리스트
+        }
+
+        return attractionRepository.findByTitleContaining(keyword).stream()
+                .map(AttractionResponse::new)
+                .collect(Collectors.toList());
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
@@ -1,4 +1,48 @@
 package com.practice.OAuth2.domain.plan.controller;
 
+import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
+import com.practice.OAuth2.domain.plan.dto.PlanJoinRequest;
+import com.practice.OAuth2.domain.plan.dto.PlanResponse;
+import com.practice.OAuth2.domain.plan.service.PlanService;
+import com.practice.OAuth2.global.security.UserPrincipal;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/plans")
 public class PlanController {
+    private final PlanService planService;
+
+    // 여행 생성
+    @PostMapping()
+    public ResponseEntity<PlanResponse> createPlan(
+            @RequestBody PlanCreateRequest request,
+            @AuthenticationPrincipal UserPrincipal principal
+            ){
+        Long userId = Long.parseLong(principal.getUsername());
+
+        PlanResponse response = planService.createPlan(request, userId);
+        return ResponseEntity.ok(response);
+    }
+
+    // 초대 코드로 입장
+    @PostMapping("/join")
+    public ResponseEntity<Long> joinPlan(
+            @RequestBody PlanJoinRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        Long planId = planService.joinPlan(request, userId);
+
+        // 성공 시 입장한 방의 ID 반환
+        return ResponseEntity.ok(planId);
+    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
@@ -4,6 +4,8 @@ import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
 import com.practice.OAuth2.domain.plan.dto.PlanJoinRequest;
 import com.practice.OAuth2.domain.plan.dto.PlanResponse;
 import com.practice.OAuth2.domain.plan.service.PlanService;
+import com.practice.OAuth2.domain.user.entity.User;
+import com.practice.OAuth2.domain.user.repository.UserRepository;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/plans")
 public class PlanController {
     private final PlanService planService;
+    private final UserRepository userRepository;
 
     // 여행 생성
     @PostMapping()
@@ -26,7 +29,11 @@ public class PlanController {
             @RequestBody PlanCreateRequest request,
             @AuthenticationPrincipal UserPrincipal principal
             ){
-        Long userId = Long.parseLong(principal.getUsername());
+        String email = principal.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        Long userId = user.getUserId();
 
         PlanResponse response = planService.createPlan(request, userId);
         return ResponseEntity.ok(response);
@@ -38,7 +45,11 @@ public class PlanController {
             @RequestBody PlanJoinRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+        String email = userDetails.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        Long userId = user.getUserId();
 
         Long planId = planService.joinPlan(request, userId);
 

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
@@ -4,6 +4,8 @@ import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
 import com.practice.OAuth2.domain.plan.dto.ScheduleMoveRequest;
 import com.practice.OAuth2.domain.plan.dto.ScheduleResizeRequest;
 import com.practice.OAuth2.domain.plan.service.ScheduleService;
+import com.practice.OAuth2.domain.user.entity.User;
+import com.practice.OAuth2.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+    private final UserRepository userRepository;
 
     // 스케줄 블록 생성
     @PostMapping("/{planId}")
@@ -49,7 +52,11 @@ public class ScheduleController {
             @RequestBody ScheduleMoveRequest request,
             @AuthenticationPrincipal UserDetails userDetails
     ) {
-        Long userId = Long.parseLong(userDetails.getUsername());
+        String email = userDetails.getUsername();
+        User user = userRepository.findByEmail(email)
+                .orElseThrow(() -> new IllegalArgumentException("가입되지 않은 이메일입니다."));
+
+        Long userId = user.getUserId();
 
         // DB 수정 -> STOMP 전송
         scheduleService.moveScheduleBlock(

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
@@ -1,6 +1,8 @@
 package com.practice.OAuth2.domain.plan.controller;
 
+import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
 import com.practice.OAuth2.domain.plan.dto.ScheduleMoveRequest;
+import com.practice.OAuth2.domain.plan.dto.ScheduleResizeRequest;
 import com.practice.OAuth2.domain.plan.service.ScheduleService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -8,6 +10,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,6 +21,26 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleController {
 
     private final ScheduleService scheduleService;
+
+    // 스케줄 블록 생성
+    @PostMapping("/{planId}")
+    public ResponseEntity<Void> createBlock(
+            @PathVariable Long planId,
+            @RequestBody ScheduleCreateRequest request
+    ) {
+        scheduleService.createScheduleBlock(planId, request);
+        return ResponseEntity.ok().build();
+    }
+
+    // 스케줄 시간 늘리기
+    @PatchMapping("/{blockId}/resize")
+    public ResponseEntity<Void> resizeBlock(
+            @PathVariable Long blockId,
+            @RequestBody ScheduleResizeRequest request
+    ) {
+        scheduleService.resizeScheduleBlock(blockId, request.getNewEndTime());
+        return ResponseEntity.ok().build();
+    }
 
     // 스케줄 이동
     @PatchMapping("/{blockId}/position")

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
@@ -1,0 +1,41 @@
+package com.practice.OAuth2.domain.plan.controller;
+
+import com.practice.OAuth2.domain.plan.dto.ScheduleMoveRequest;
+import com.practice.OAuth2.domain.plan.service.ScheduleService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/schedules")
+public class ScheduleController {
+
+    private final ScheduleService scheduleService;
+
+    // 스케줄 이동
+    @PatchMapping("/{blockId}/position")
+    public ResponseEntity<Void> moveScheduleBlock(
+            @PathVariable Long blockId,
+            @RequestBody ScheduleMoveRequest request,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        Long userId = Long.parseLong(userDetails.getUsername());
+
+        // DB 수정 -> STOMP 전송
+        scheduleService.moveScheduleBlock(
+                userId,
+                blockId,
+                request.getNewDay(),
+                request.getNewStartTime()
+        );
+
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
@@ -1,0 +1,36 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+@Getter
+@NoArgsConstructor
+// 사용자가 여행 만들거나, 입장할때
+public class PlanCreateRequest {
+
+    @NonNull
+    private String title;
+
+    @NonNull
+    private LocalDate startDate;
+
+    @NonNull
+    private LocalDate endDate;
+
+    @NonNull
+    private String planImageUrl;
+
+    // DTO -> Entity 변환 메서드 (서비스 로직 단축용)
+    public Plan toEntity() {
+        return Plan.builder()
+                .title(this.title)
+                .startDate(this.startDate)
+                .endDate(this.endDate)
+                .planImageUrl(this.planImageUrl)
+                .build();
+        // inviteCode는 엔티티 생성자(Builder) 안에서 자동 생성
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanJoinRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanJoinRequest.java
@@ -1,0 +1,14 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 친구 초대 코드로 입장
+public class PlanJoinRequest {
+
+    @NotBlank
+    private String inviteCode;
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanMemberResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanMemberResponse.java
@@ -1,0 +1,21 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.plan.entity.PlanMember;
+import lombok.Getter;
+
+@Getter
+// 참여자 정보
+public class PlanMemberResponse {
+    private Long memberId;
+    private Long userId;
+    private String nickname;
+    private String profileImageUrl;
+
+    public PlanMemberResponse(PlanMember planMember) {
+        this.memberId = planMember.getMemberId();
+        // PlanMember -> User 접근
+        this.userId = planMember.getUser().getUserId();
+        this.nickname = planMember.getUser().getNickname(); // User 엔티티 필드명에 맞게 수정
+        this.profileImageUrl = planMember.getUser().getProfileImageUrl();
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanResponse.java
@@ -1,0 +1,26 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import java.time.LocalDate;
+import lombok.Getter;
+
+@Getter
+// 여행 정보 조회시 프론트엔드에 전송
+public class PlanResponse {
+    private Long planId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String planImageUrl;
+    private String inviteCode; // 친구 초대용 코드
+
+    // Entity -> DTO 생성자
+    public PlanResponse(Plan plan) {
+        this.planId = plan.getPlanId();
+        this.title = plan.getTitle();
+        this.startDate = plan.getStartDate();
+        this.endDate = plan.getEndDate();
+        this.planImageUrl = plan.getPlanImageUrl();
+        this.inviteCode = plan.getInviteCode();
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleBlockResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleBlockResponse.java
@@ -1,0 +1,32 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
+import java.time.LocalTime;
+import lombok.Getter;
+
+@Getter
+public class ScheduleBlockResponse {
+    private Long blockId;
+    private Long planId;      // Plan 전체 대신 ID만 보냄
+    private AttractionResponse attraction; // Attraction도 DTO로 변환
+    private Integer day;
+    private String title;
+    private LocalTime startTime;
+    private LocalTime endTime;
+
+    public ScheduleBlockResponse(ScheduleBlock block) {
+        this.blockId = block.getBlockId();
+        this.planId = block.getPlan().getPlanId();
+
+        // Attraction이 있으면 DTO로 변환, 없으면(빈 블록) null
+        if (block.getAttraction() != null) {
+            this.attraction = new AttractionResponse(block.getAttraction());
+        }
+
+        this.day = block.getDay();
+        this.title = block.getTitle();
+        this.startTime = block.getStartTime();
+        this.endTime = block.getEndTime();
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleCreateRequest.java
@@ -8,7 +8,7 @@ import lombok.NoArgsConstructor;
 @Getter
 @NoArgsConstructor
 public class ScheduleCreateRequest {
-    private Attraction attraction;
+    private Integer attractionId;
     private Integer day;
     private String title;
     private LocalTime startTime;

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleCreateRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleCreateRequest.java
@@ -1,0 +1,15 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ScheduleCreateRequest {
+    private Attraction attraction;
+    private Integer day;
+    private String title;
+    private LocalTime startTime;
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleMoveRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleMoveRequest.java
@@ -1,0 +1,12 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ScheduleMoveRequest {
+    private Integer newDay;       // 몇 일차로 옮겼는지
+    private LocalTime newStartTime; // 몇 시로 옮겼는지
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleResizeRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleResizeRequest.java
@@ -1,0 +1,11 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import java.time.LocalTime;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ScheduleResizeRequest {
+    private LocalTime newEndTime;
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
@@ -13,6 +13,9 @@ import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
@@ -20,7 +23,9 @@ import org.hibernate.annotations.Where;
 
 @Entity
 @Getter
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Table(name = "schedule_blocks")
 @SQLDelete(sql = "UPDATE schedule_blocks SET deleted_at = NOW() WHERE block_id = ?")
 @Where(clause = "deleted_at IS NULL")
@@ -53,8 +58,14 @@ public class ScheduleBlock extends BaseEntity {
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
 
+    // 블록 옮기기
     public void changePosition(Integer day, LocalTime startTime) {
         this.day = day;
         this.startTime = startTime;
+    }
+
+    // 블록 시간 조정하기
+    public void updateEndTime(LocalTime endTime) {
+        this.endTime = endTime;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
@@ -52,4 +52,9 @@ public class ScheduleBlock extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    public void changePosition(Integer day, LocalTime startTime) {
+        this.day = day;
+        this.startTime = startTime;
+    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/MemoRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/MemoRepository.java
@@ -1,0 +1,10 @@
+package com.practice.OAuth2.domain.plan.repository;
+
+import com.practice.OAuth2.domain.plan.entity.Memo;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface MemoRepository extends JpaRepository<Memo, Long> {
+    // 스케줄 블럭에 달린 메모 조회
+    List<Memo> findAllByScheduleBlock_BlockId(Long blockId);
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanMemberRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanMemberRepository.java
@@ -1,0 +1,33 @@
+package com.practice.OAuth2.domain.plan.repository;
+
+import com.practice.OAuth2.domain.plan.entity.Memo;
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import com.practice.OAuth2.domain.plan.entity.PlanMember;
+import com.practice.OAuth2.domain.user.entity.User;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.EntityGraph;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanMemberRepository extends JpaRepository<PlanMember, Long> {
+
+    // 1. 특정 여행의 현재 참여 중인 멤버 목록 조회 (나간 사람 제외)
+    // 용도: 채팅방 참여자 목록 표시, Redis 캐싱용
+    // @EntityGraph는 User 정보를 한 번에 가져와서 N+1 문제를 방지함
+    @EntityGraph(attributePaths = {"user"})
+    List<PlanMember> findByPlan_PlanIdAndLeftAtIsNull(Long planId);
+
+    // 2. 내가 참여 중인 여행 목록 조회
+    @EntityGraph(attributePaths = {"plan"})
+    List<PlanMember> findByUser_UserIdAndLeftAtIsNull(Long userId);
+
+    // 3. 특정 유저가 이 방에 들어온 적이 있는지 확인 (재입장 로직용)
+    // leftAt 상관없이 기록 자체를 찾음
+    Optional<PlanMember> findByPlanAndUser(Plan plan, User user);
+
+    // 4.STOMP 인터셉터 권한 체크용
+    boolean existsByPlan_PlanIdAndUser_UserIdAndLeftAtIsNull(Long planId, Long userId);
+
+    // 5. 방의 인원수 체크 (Redis가 없을 때 백업용)
+    long countByPlan_PlanIdAndLeftAtIsNull(Long planId);
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanRepository.java
@@ -1,0 +1,10 @@
+package com.practice.OAuth2.domain.plan.repository;
+
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PlanRepository extends JpaRepository<Plan, Long> {
+    // 초대 코드로 여행 계획 조회 (친구 초대 링크 클릭 시 사용)
+    Optional<Plan> findByInviteCode(String inviteCode);
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/ScheduleBlockRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/ScheduleBlockRepository.java
@@ -1,0 +1,9 @@
+package com.practice.OAuth2.domain.plan.repository;
+
+import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ScheduleBlockRepository extends JpaRepository<ScheduleBlock, Long> {
+    List<ScheduleBlock> findAllByPlan_PlanIdOrderByDayAscStartTimeAsc(Long planId);
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
@@ -1,6 +1,8 @@
 package com.practice.OAuth2.domain.plan.service;
 
 import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
+import com.practice.OAuth2.domain.plan.dto.PlanJoinRequest;
+import com.practice.OAuth2.domain.plan.dto.PlanMemberResponse;
 import com.practice.OAuth2.domain.plan.dto.PlanResponse;
 import com.practice.OAuth2.domain.plan.entity.Plan;
 import com.practice.OAuth2.domain.plan.entity.PlanMember;
@@ -8,7 +10,9 @@ import com.practice.OAuth2.domain.plan.repository.PlanMemberRepository;
 import com.practice.OAuth2.domain.plan.repository.PlanRepository;
 import com.practice.OAuth2.domain.user.entity.User;
 import com.practice.OAuth2.domain.user.repository.UserRepository;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,6 +22,9 @@ public class PlanService {
     private final PlanRepository planRepository;
     private final PlanMemberRepository planMemberRepository;
     private final UserRepository userRepository;
+
+    // STOMP 메시지 전송용 (드래그 앤 드롭에 쓰임)
+    private final SimpMessagingTemplate messagingTemplate;
 
     // 여행 생성
     @Transactional
@@ -39,6 +46,44 @@ public class PlanService {
 
         // inviteCode가 포함된 응답이 나감
         return new PlanResponse(plan);
+    }
+
+    // 친구 초대
+    // db 업데이트 + 실시간 입장 알림 전송
+    @Transactional
+    public Long joinPlan(PlanJoinRequest request, Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("사용자를 찾을 수 없습니다."));
+
+        Plan plan = planRepository.findByInviteCode(request.getInviteCode())
+                .orElseThrow(() -> new IllegalArgumentException("유효하지 않은 초대 코드입니다."));
+
+        // 이 여행 멤버인지 확인
+        Optional<PlanMember> existingMember = planMemberRepository.findByPlanAndUser(plan, user);
+
+        PlanMember planMember;
+        if (existingMember.isPresent()) {
+            planMember = existingMember.get();
+            // 이미 참여중이면
+            if (planMember.getLeftAt() == null) {
+                throw new IllegalStateException("이미 참여 중인 여행입니다.");
+            }
+            // 나갔던 멤버면 재입장 (leftAt -> null)
+            planMember.reJoin();
+        } else {
+            // 새로 들어온 경우
+            planMember = PlanMember.builder()
+                    .plan(plan)
+                    .user(user)
+                    .build();
+            planMemberRepository.save(planMember);
+        }
+
+        // STOMP 알림 전송 (화면 갱신해야 하니까)
+        PlanMemberResponse responseDto = new PlanMemberResponse(planMember);
+        messagingTemplate.convertAndSend("/topic/plans/" + plan.getPlanId(), responseDto);
+
+        return plan.getPlanId();
     }
 
     // 여행 수정

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
@@ -1,0 +1,47 @@
+package com.practice.OAuth2.domain.plan.service;
+
+import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
+import com.practice.OAuth2.domain.plan.dto.PlanResponse;
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import com.practice.OAuth2.domain.plan.entity.PlanMember;
+import com.practice.OAuth2.domain.plan.repository.PlanMemberRepository;
+import com.practice.OAuth2.domain.plan.repository.PlanRepository;
+import com.practice.OAuth2.domain.user.entity.User;
+import com.practice.OAuth2.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PlanService {
+    private final PlanRepository planRepository;
+    private final PlanMemberRepository planMemberRepository;
+    private final UserRepository userRepository;
+
+    // 여행 생성
+    @Transactional
+    public PlanResponse createPlan(PlanCreateRequest request, Long userId){
+        User user = userRepository.findById(userId)
+                .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 사용자"));
+
+        Plan plan = request.toEntity();
+        planRepository.save(plan);
+
+        // 최초 등록
+        PlanMember firstMember = PlanMember.builder()
+                .plan(plan)
+                .user(user)
+                .build();
+
+        // plan_Members 테이블에 이 사용자 추가
+        planMemberRepository.save(firstMember);
+
+        // inviteCode가 포함된 응답이 나감
+        return new PlanResponse(plan);
+    }
+
+    // 여행 수정
+
+    // 여행 삭제
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
@@ -1,6 +1,11 @@
 package com.practice.OAuth2.domain.plan.service;
 
+import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import com.practice.OAuth2.domain.attraction.repository.AttractionRepository;
+import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
+import com.practice.OAuth2.domain.plan.entity.Plan;
 import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
+import com.practice.OAuth2.domain.plan.repository.PlanRepository;
 import com.practice.OAuth2.domain.plan.repository.ScheduleBlockRepository;
 import java.time.LocalTime;
 import lombok.RequiredArgsConstructor;
@@ -14,10 +19,53 @@ import org.springframework.transaction.annotation.Transactional;
 // 스케줄 블록을 옮겼을 때, publish 하기
 public class ScheduleService {
 
+    private final PlanRepository planRepository;
+    private final AttractionRepository attractionRepository;
     private final ScheduleBlockRepository scheduleBlockRepository;
-
     private final SimpMessagingTemplate messagingTemplate;
 
+    // 블록 생성
+    public void createScheduleBlock(Long planId, ScheduleCreateRequest request) {
+        Plan plan = planRepository.findById(planId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 여행입니다."));
+
+        // 장소 정보 조회 (null일 수 있음)
+        Attraction attraction = null;
+        if (request.getAttractionId() != null) {
+            attraction = attractionRepository.findById(request.getAttractionId())
+                    .orElse(null);
+        }
+
+        // 엔티티 생성 (기본 30분 설정)
+        ScheduleBlock block = ScheduleBlock.builder()
+                .plan(plan)
+                .attraction(attraction)
+                .day(request.getDay())
+                .startTime(request.getStartTime())
+                .endTime(request.getStartTime().plusMinutes(30)) // 기본 30분
+                .title(request.getTitle()) // 장소명이거나 사용자 입력 제목
+                .build();
+
+        scheduleBlockRepository.save(block);
+
+        // [STOMP] 생성된 블록 정보를 방 전체에 전송 (Type: CREATE)
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/create", block);
+    }
+
+    // 블록 크기 조절
+    public void resizeScheduleBlock(Long blockId, LocalTime newEndTime) {
+        ScheduleBlock block = scheduleBlockRepository.findById(blockId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 블록입니다."));
+
+        // 시간 업데이트 (엔티티 내부에 updateEndTime 메서드 필요)
+        block.updateEndTime(newEndTime);
+
+        // [STOMP] 변경된 정보 전송 (Type: UPDATE)
+        Long planId = block.getPlan().getPlanId();
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/update", block);
+    }
+
+    // 블록 이동
     public void moveScheduleBlock(Long userId, Long blockId, Integer newDay, LocalTime newStartTime) {
         // 1. 블록 조회
         ScheduleBlock block = scheduleBlockRepository.findById(blockId)

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
@@ -1,0 +1,41 @@
+package com.practice.OAuth2.domain.plan.service;
+
+import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
+import com.practice.OAuth2.domain.plan.repository.ScheduleBlockRepository;
+import java.time.LocalTime;
+import lombok.RequiredArgsConstructor;
+import org.springframework.messaging.simp.SimpMessagingTemplate;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+// 스케줄 블록을 옮겼을 때, publish 하기
+public class ScheduleService {
+
+    private final ScheduleBlockRepository scheduleBlockRepository;
+
+    private final SimpMessagingTemplate messagingTemplate;
+
+    public void moveScheduleBlock(Long userId, Long blockId, Integer newDay, LocalTime newStartTime) {
+        // 1. 블록 조회
+        ScheduleBlock block = scheduleBlockRepository.findById(blockId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 블록입니다."));
+
+        // 이 방 멤버인지 확인 필요?
+
+        // 2. 블록 옮겼을때 바뀐 정보 업데이트
+        block.changePosition(newDay, newStartTime);
+
+        // 3. [STOMP] 실시간 동기화
+        // "10번 방의 스케줄이 변경되었으니, 새로고침"
+        Long planId = block.getPlan().getPlanId();
+
+        // 변경된 블록 정보만 보내거나, 해당 날짜의 전체 리스트를 보내서 덮어씌우게 함
+        // "UPDATE"라는 신호와 함께 변경된 블록 정보를 보냄
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules", block);
+    }
+
+
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
@@ -12,6 +12,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import com.practice.OAuth2.domain.plan.dto.ScheduleBlockResponse;
 
 @Service
 @RequiredArgsConstructor
@@ -48,8 +49,10 @@ public class ScheduleService {
 
         scheduleBlockRepository.save(block);
 
+        // 엔티티 -> DTO 변환 후 전송
+        ScheduleBlockResponse response = new ScheduleBlockResponse(block);
         // [STOMP] 생성된 블록 정보를 방 전체에 전송 (Type: CREATE)
-        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/create", block);
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/create", response);
     }
 
     // 블록 크기 조절
@@ -62,7 +65,9 @@ public class ScheduleService {
 
         // [STOMP] 변경된 정보 전송 (Type: UPDATE)
         Long planId = block.getPlan().getPlanId();
-        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/update", block);
+
+        ScheduleBlockResponse response = new ScheduleBlockResponse(block);
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules/update", response);
     }
 
     // 블록 이동
@@ -80,9 +85,10 @@ public class ScheduleService {
         // "10번 방의 스케줄이 변경되었으니, 새로고침"
         Long planId = block.getPlan().getPlanId();
 
+        ScheduleBlockResponse response = new ScheduleBlockResponse(block);
         // 변경된 블록 정보만 보내거나, 해당 날짜의 전체 리스트를 보내서 덮어씌우게 함
         // "UPDATE"라는 신호와 함께 변경된 블록 정보를 보냄
-        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules", block);
+        messagingTemplate.convertAndSend("/topic/plans/" + planId + "/schedules", response);
     }
 
 

--- a/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
@@ -104,6 +104,8 @@ public class SecurityConfig {
                         .permitAll()
                     .requestMatchers( "/api/auth/**", "/oauth2/**")
                         .permitAll()
+                    .requestMatchers("/ws/**")
+                        .permitAll()
                     .anyRequest()
                         .authenticated()
                     .and()

--- a/src/main/java/com/practice/OAuth2/global/config/WebSocketConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/WebSocketConfig.java
@@ -15,6 +15,7 @@ public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
         registry.addEndpoint("/ws")
                 .setAllowedOriginPatterns("*")
                 .withSockJS();
+        // 포스트맨으로 웹소켓 테스트시 SockJS 주석 필요
     }
 
     @Override


### PR DESCRIPTION
## 📌관련 이슈
- closed: #48
## 💥작업 내용
- 여행 생성 기능
- 초대 코드 이용해서 바로 들어오는 기능
- 스케줄링 기능(Plan)
  - 장소 검색(Attraction)
  - 장소 검색한것 드래그 앤 드랍
  - 일정 다른 날짜/시간으로 옮기기[position]
  - 일정 시간 늘리기[resize]
- 웹소켓(Stomp) 설정 
- api 테스트(성공)
  - 여행 만들기
    <img width="500" height="300" alt="여행 만들기" src="https://github.com/user-attachments/assets/7564a132-4189-4d18-a88f-5796e1241294" />
  - 웹소켓 구독하기
  - 장소 검색하기
    <img width="500" height="300" alt="장소 검색" src="https://github.com/user-attachments/assets/7ed0fe5f-2cec-4348-947c-17406d3ae440" />
  - 스케줄 블럭 생성 
  - 스케줄 블럭 시간 늘리기
  - 스케즐 블럭 날짜 바꾸기 
    <img width="500" height="300" alt="날짜 바꾸기" src="https://github.com/user-attachments/assets/4ab63d9b-cb6c-4a18-9456-c4bf1b752b60" />

  - 블럭 생성하기로 웹소켓 테스트
    <img width="500" height="300" alt="블럭생성하기웹소켓" src="https://github.com/user-attachments/assets/55ff5add-e14c-49e6-a231-5a4fc601511b" />

## ✨참고 사항 
- redis 사용 x -> redis 이용 추가 수정 필요
- crud 더 필요 
- 메모기능 구현 필요
- postman에서는 stomp 이용하기 어려움 -> html만들어서 따로 확인하기 
- [Trouble Shooting] 사용자 ID 파싱 오류
  - UserRepository.findByEmail()을 호출하여 이메일로 회원 엔티티를 조회한 후 ID를 추출하는 방식으로 로직 변경
- [Trouble Shooting] 웹소켓 핸드셰이크 인증 실패
  - SecurityConfig에서 설정을 추가
- [Trouble Shooting] 웹소켓 프로토콜 불일치
  - WebSocketConfig에서 .withSockJS() 옵션을 제거하여 표준 웹소켓 연결을 지원
- [Trouble Shooting] JPA 엔티티 JSON 변환 오류
  - 엔티티를 그대로 반환하지 않고, 필요한 데이터만 담은 Response DTO(ScheduleBlockResponse)를 만들어 변환 후 전송
- 파일 구조
 ```
domain
  └── plan
        ├── controller
        │   ├── PlanController.java       # 여행 생성 및 초대 코드 입장 API
        │   ├── ScheduleController.java   # 스케줄 블록 생성/이동/시간조절 API
        │   └── PlanWebSocketController.java      # 원래 있던것 
        │
        ├── service
        │   ├── PlanService.java          # 여행 방 생성, 멤버 추가 및 입장 알림 로직
        │   └── ScheduleService.java      # 스케줄 CRUD + STOMP 실시간 동기화(Pub) 로직
        │
        ├── repository
        │   ├── PlanRepository.java       # 초대 코드로 여행 조회
        │   ├── PlanMemberRepository.java       # 멤버 권한 및 존재 여부 확인
        │   ├── MemoRepository.java        # 메모 조회(저장, 삭제 추가 필요)
        │   └── ScheduleBlockRepository.java        # 스케줄 블록 조회(저장, 삭제 추가 필요)
        │
        ├── entity
        │   ├── Plan.java                 # 여행 계획 (초대코드 포함)
        │   ├── PlanMember.java           # 여행 참여 멤버 (방 나가기 기능 포함)
        │   ├── ScheduleBlock.java        # 상세 일정 블록 (장소, 시간, 위치 정보)
        │   └── Memo.java                 # 블록 내 메모 (텍스트/링크)
        │
        └── dto
            ├── PlanCreateRequest.java  # 여행 생성 요청 데이터
            ├── PlanJoinRequest.java  # 친구 초대 코드로 입장 요청 데이터
            ├── PlanResponse.java  # 여행 정보 조회 응답. 초대 코드를 포함하여 반환
            ├── PlanMemberResponse.java  # 참여자 정보
            ├── ScheduleCreateRequest.java  # 스케줄 생성 요청
            ├── ScheduleMoveRequest.java  # 드래그 앤 드롭 이동 정보
            ├── ScheduleResizeRequest.java  # 시간 늘리기 정보
            └── ScheduleBlockResponse.java  # STOMP 전송 시 JPA 프록시 에러 해결용
```