### PR TITLE
Refactor : 토큰 재발급 동시성 백엔드에서 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ repositories {
 
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'org.redisson:redisson-spring-boot-starter:3.24.0'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-security'

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -27,7 +27,7 @@ public class AuthService {
 
     private final RedisTemplate<String, Object> redisTemplate;
 
-    @Transactional
+//  Redis 는 @Transactional 제거 : Race Condition 대비해야하는데 .save()가 즉시 반영이 안되므로
     public TokenResponse reissue(String refreshToken) {
         if (refreshToken == null) {
             throw new BadRequestException("리프레시 토큰을 받지 못했습니다.");
@@ -41,7 +41,7 @@ public class AuthService {
            캐시엔트리 유예기간 : 10초 설정 */
         TokenResponse cachedToken = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
         if (cachedToken != null) {
-            log.info("Grace Period 적중");
+            log.info("Grace Period 캐싱 적중");
             return cachedToken;
         }
 
@@ -49,11 +49,12 @@ public class AuthService {
             throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
         }
 
-        // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교
-        String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
-        // 속도를 위해 PK (id) 사용
-        RefreshToken redisToken = refreshTokenRepository.findById(userId).orElse(null);
+        // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교 하기 위한
+        // Old Token 의 레디스 키 명
+        String oldTokenUserId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
 
+        // 속도를 위해 PK (id) 사용
+        RefreshToken redisToken = refreshTokenRepository.findById(oldTokenUserId).orElse(null);
         if (redisToken == null) {
             throw new BadRequestException("만료된 리프레시 토큰입니다.");
         } else if (!redisToken.getToken().equals(refreshToken)) {
@@ -64,15 +65,34 @@ public class AuthService {
 
         // 새 토큰 생성을 위한 Authentication 객체 생성 (ID만 있으면 됨)
         // TokenProvider는 토큰을 만들 때 Authentication 안에 있는 UserPrincipal을 꺼내고, 그 안의 id를 써서 토큰을 만들도록 되어있음
-        UserDetails principal = UserPrincipal.create(Long.parseLong(userId));
+        UserDetails principal = UserPrincipal.create(Long.parseLong(oldTokenUserId));
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
 
         // 새 토큰 발급 (RTR: Refresh Token도 새로 발급)
         String newAccessToken = tokenProvider.createToken(authentication);
         String newRefreshToken = tokenProvider.createRefreshToken(authentication);
 
-        // Redis 업데이트
-        refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
+        // Race Condition 체크 시작 : 현재 쓰레드가 재발급 로직을 수행하는 동안,
+        // 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했는지
+
+        // 재발급 로직 이후에 다시 oldTokenUserId 로 토큰 가져옴
+        RefreshToken currentRedisToken = refreshTokenRepository.findById(oldTokenUserId).orElse(null);
+
+        // 현재 쓰레드가 재발급 로직을 수행하는 동안, 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했다면
+        if (currentRedisToken == null || !currentRedisToken.getToken().equals(refreshToken)) {
+            log.info("Race Condition 감지");
+
+            // 늦게 온 쓰레드는 여기서 1등의 값을 가져감 ( Grace Period 적중 과 동일하게 취급 )
+            TokenResponse luckyFind = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
+            if (luckyFind != null) {
+                return luckyFind;
+            } else {
+                throw new BadRequestException("이미 갱신된 토큰입니다. 다시 시도해주세요.");
+            }
+        } // Race Condition 체크 끝, 아래 부터는 1등 쓰레드만이 접근 가능한 코드
+
+        // Redis 업데이트 (1등 쓰레드만이 Grace Period 적중이 안되고 Race Condition 감지도 안되어져서 DB 작업 수행)
+        refreshTokenRepository.save(new RefreshToken(oldTokenUserId, newRefreshToken));
 
         TokenResponse tokenResponse = TokenResponse.builder()
                 .accessToken(newAccessToken)
@@ -80,12 +100,13 @@ public class AuthService {
                 .build();
 
         // 1등이 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키에 재발급한 리프레시 토큰을 value 로 설정
+        // 트랜잭셔널 없으므로 즉시 반영
         redisTemplate.opsForValue().set(graceKey, tokenResponse, 10, TimeUnit.SECONDS);
 
         return tokenResponse;
     }
 
-    @Transactional
+//    @Transactional 제거 : Redis 는 즉시 반영
     public void logout(String refreshToken) {
 
         if (refreshToken == null) {

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -8,6 +8,8 @@ import com.practice.OAuth2.global.security.TokenProvider;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.redisson.api.RLock;
+import org.redisson.api.RedissonClient;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -15,6 +17,8 @@ import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
@@ -24,8 +28,11 @@ public class AuthService {
 
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenProvider tokenProvider;
+    private final RedissonClient redissonClient;      // 락 제어용
+    private final RedisTemplate<String, Object> redisTemplate; // 결과 공유용 캐시 저장소
 
-    private final RedisTemplate<String, Object> redisTemplate;
+    // 1등 쓰레드의 결과물이 유지되는 시간 (3초)
+    private static final long RESULT_TTL_MS = 3000;
 
 //  Redis 는 @Transactional 제거 : Race Condition 대비해야하는데 .save()가 즉시 반영이 안되므로
     public TokenResponse reissue(String refreshToken) {
@@ -33,87 +40,116 @@ public class AuthService {
             throw new BadRequestException("리프레시 토큰을 받지 못했습니다.");
         }
 
-        // ============================== Grace Period 검증 시작 ======================================
+        // Key, value 지정 및 최적화 : 토큰이 너무 기니까 해싱해서 짧게 만듦 (메모리 절약 + 성능 향상)
+        String hashedToken = sha256(refreshToken);
+        String lockKey = "reissue:lock:" + hashedToken;
+        String resultKey = "reissue:result:" + hashedToken; // 1등이 완료했을때 키 명
 
-        // 10초 유예기간 캐시저장소의 키 이름 설정 : 어떤 Old Token(파라미터로 온 refreshToken)이 요청했는지를 식별하기 위함
-        String graceKey = "grace_period:" + refreshToken;
-
-        /* 레디스 캐시저장소에 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키를 가진 캐시 엔트리가 존재한다면
-           1등이 Old Token 을 써서 재발급 했었다는 뜻 -> 이 캐시 엔트리는 재발급된 리프레시 토큰이므로 바로 이 데이터 응답,
-           캐시엔트리 유예기간 : 10초 설정 */
-        TokenResponse cachedToken = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
-        if (cachedToken != null) {
-            log.info("Grace Period 캐싱 적중");
-            return cachedToken;
+        // 완전 후발주자는 락 잡기 전에 캐시 확인해서 1등이 만든 캐시 엔트리가 있다면 바로 리턴
+        TokenResponse cachedResult = (TokenResponse) redisTemplate.opsForValue().get(resultKey);
+        if (cachedResult != null) {
+            log.info("redisson lock 진입 전 Result Cashing 수행");
+            return cachedResult;
         }
 
-        // ============================== Grace Period 검증 끝 ======================================
+        // Redisson Lock 줄 서기
+        RLock lock = redissonClient.getLock(lockKey);
 
-        if (!tokenProvider.validateToken(refreshToken)) {
-            throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
-        }
+        try {
+            // waitTime 3초: 2등은 3초간 얌전히 대기 (Pub/Sub 방식이라 서버 부하 적음)
+            // leaseTime 5초: 1등이 죽어도 5초 뒤 자동 해제 (데드락 방지)
+            boolean isLocked = lock.tryLock(3, 5, TimeUnit.SECONDS);
 
-        // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교 하기 위한
-        // Old Token 의 레디스 키 명
-        String oldTokenUserId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
+            if (!isLocked) {
+                // 락 획득 실패 (시스템 과부하 등) -> 마지막으로 정답지 한번 더 확인
+                TokenResponse finalCheck = (TokenResponse) redisTemplate.opsForValue().get(resultKey);
+                if (finalCheck != null) return finalCheck;
 
-        // 속도를 위해 PK (id) 사용
-        RefreshToken redisToken = refreshTokenRepository.findById(oldTokenUserId).orElse(null);
-        if (redisToken == null) {
-            throw new BadRequestException("만료된 리프레시 토큰입니다.");
-        } else if (!redisToken.getToken().equals(refreshToken)) {
-            throw new BadRequestException("리프레시 토큰이 만료되었습니다.");
-        }
+                throw new BadRequestException("요청이 너무 많습니다. 잠시 후 다시 시도해주세요.");
+            }
 
-        // 재발급 로직
+            // 1등 락 풀고 진입 / 2등은 대기 후 진입
 
-        // 새 토큰 생성을 위한 Authentication 객체 생성 (ID만 있으면 됨)
-        // TokenProvider는 토큰을 만들 때 Authentication 안에 있는 UserPrincipal을 꺼내고, 그 안의 id를 써서 토큰을 만들도록 되어있음
-        UserDetails principal = UserPrincipal.create(Long.parseLong(oldTokenUserId));
-        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
+            // Double Check : 1등 이후의 쓰레드들은 1등이 끝낸 작업 (키 명: resultKey) 을 바로 리턴
+            TokenResponse winnerResult = (TokenResponse) redisTemplate.opsForValue().get(resultKey);
+            if (winnerResult != null) {
+                log.info("Result Caching 수행");
+                return winnerResult; // 2등부터 여기서 리턴 (DB 접근 안하게)
+            }
 
-        // 새 토큰 발급 (RTR: Refresh Token도 새로 발급)
-        String newAccessToken = tokenProvider.createToken(authentication);
-        String newRefreshToken = tokenProvider.createRefreshToken(authentication);
+            // =======================================================
+            // 지금부터 1등 쓰레드만 실행하는 구역 (DB 작업)
+            // =======================================================
 
-        //================================ Race Condition 체크 시작 =====================================
+            // 유효성 검사
+            if (!tokenProvider.validateToken(refreshToken)) {
+                throw new BadRequestException("유효하지 않은 토큰");
+            }
 
-        // 현재 쓰레드가 재발급 로직을 수행하는 동안 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했는지
+            // 브라우저에게 쿠키로 받은 리프레시 토큰과 Redis 저장소(TTL: 14일)에 있는 리프레시토큰을 비교 하기 위한
+            // 브라우저에게 받은 리프레시토큰의 레디스 키 명 추출
+            String userId = String.valueOf(tokenProvider.getUserIdFromToken(refreshToken));
 
-        // 재발급 로직 이후에 다시 oldTokenUserId 로 토큰 가져옴
-        RefreshToken currentRedisToken = refreshTokenRepository.findById(oldTokenUserId).orElse(null);
+            // DB 상태 확인 (토큰 삭제/만료 여부 검증 : 속도를 위해 PK (id) 사용)
+            RefreshToken dbToken = refreshTokenRepository.findById(userId).orElse(null);
+            // 브라우저에게 받은 리프레시토큰이 Redis 저장소에 없거나 value 가 다르다면 예외
+            if (dbToken == null || !dbToken.getToken().equals(refreshToken)) {
+                throw new BadRequestException("이미 만료되었거나 갱신된 토큰입니다.");
+            }
 
-        // 현재 쓰레드가 재발급 로직을 수행하는 동안, 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했다면
-        if (currentRedisToken == null || !currentRedisToken.getToken().equals(refreshToken)) {
-            log.info("Race Condition 감지");
+            // 재발급 로직
+            // 새 토큰 생성을 위한 Authentication 객체 생성 (ID만 있으면 됨)
+            // TokenProvider 는 토큰을 만들 때 Authentication 안에 있는 UserPrincipal을 꺼내고, 그 안의 id를 써서 토큰을 만들도록 되어있음
+            UserDetails principal = UserPrincipal.create(Long.parseLong(userId));
+            Authentication authentication = new UsernamePasswordAuthenticationToken(principal, null, Collections.emptyList());
 
-            // 늦게 온 쓰레드는 여기서 1등의 값을 가져감 ( Grace Period 적중 과 동일하게 취급 )
-            TokenResponse luckyFind = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
-            if (luckyFind != null) {
-                return luckyFind;
-            } else {
-                throw new BadRequestException("이미 갱신된 토큰입니다. 다시 시도해주세요.");
+            // 새 토큰 발급 (RTR: Refresh Token 도 새로 발급) 및 쿠키에 보낼 응답 설정
+            String newAccessToken = tokenProvider.createToken(authentication);
+            String newRefreshToken = tokenProvider.createRefreshToken(authentication);
+            TokenResponse newTokenResponse = new TokenResponse(newAccessToken, newRefreshToken);
+
+            // Redis DB 리프레시 토큰 업데이트 ( 기존 키에 값을 덮어 씌우기 )
+            refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
+
+            // 결과 공유 : 재발급 갱신 된 쿠키에 보낼 응답 등록 (TTL 3초), 키 resultKey : 값 newTokenResponse
+            // 1등이 이걸 저장해야 2등부터 Double Check 에서 받아감
+            redisTemplate.opsForValue().set(resultKey, newTokenResponse, RESULT_TTL_MS, TimeUnit.MILLISECONDS);
+
+            log.info("첫번째 쓰레드로 DB 갱신 및 결과 공유 캐싱 완료");
+            return newTokenResponse;
+
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Lock process interrupted");
+        } finally {
+            // Safe Unlock : 안전한 락 해제
+            try {
+                // "락이 잠겨있고 && 내가 주인이면" 해제
+                if (lock.isLocked() && lock.isHeldByCurrentThread()) {
+                    lock.unlock();
+                }
+            } catch (IllegalMonitorStateException e) {
+                // 이미 타임아웃으로 락이 사라졌거나, 다른 스레드가 푼 경우 (무시)
+                log.warn("Redisson Lock already unlocked: {} - {}", lockKey, e.getMessage());
             }
         }
+    }
 
-        //================================ Race Condition 체크 끝 =====================================
-
-        // 아래의 Redis 반영은 경쟁 상태가 발생해도 상관없는 구조
-
-        // Redis 업데이트 (1등 쓰레드만이 Grace Period 적중이 안되고 Race Condition 감지도 안되어져서 DB 작업 수행)
-        refreshTokenRepository.save(new RefreshToken(oldTokenUserId, newRefreshToken));
-
-        TokenResponse tokenResponse = TokenResponse.builder()
-                .accessToken(newAccessToken)
-                .refreshToken(newRefreshToken)
-                .build();
-
-        // Grace_period 설정
-        // 1등이 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키에 재발급한 리프레시 토큰을 value 로 설정
-        // 트랜잭셔널 없으므로 즉시 반영
-        redisTemplate.opsForValue().set(graceKey, tokenResponse, 10, TimeUnit.SECONDS);
-
-        return tokenResponse;
+    // SHA-256 해싱 유틸
+    private String sha256(String original) {
+        try {
+            MessageDigest md = MessageDigest.getInstance("SHA-256");
+            byte[] hash = md.digest(original.getBytes(StandardCharsets.UTF_8));
+            StringBuilder hexString = new StringBuilder();
+            for (byte b : hash) {
+                String hex = Integer.toHexString(0xff & b);
+                if (hex.length() == 1) hexString.append('0');
+                hexString.append(hex);
+            }
+            return hexString.toString();
+        } catch (Exception e) {
+            throw new RuntimeException("Hashing failed", e);
+        }
     }
 
 //    @Transactional 제거 : Redis 는 즉시 반영

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -33,6 +33,8 @@ public class AuthService {
             throw new BadRequestException("리프레시 토큰을 받지 못했습니다.");
         }
 
+        // ============================== Grace Period 검증 시작 ======================================
+
         // 10초 유예기간 캐시저장소의 키 이름 설정 : 어떤 Old Token(파라미터로 온 refreshToken)이 요청했는지를 식별하기 위함
         String graceKey = "grace_period:" + refreshToken;
 
@@ -44,6 +46,8 @@ public class AuthService {
             log.info("Grace Period 캐싱 적중");
             return cachedToken;
         }
+
+        // ============================== Grace Period 검증 끝 ======================================
 
         if (!tokenProvider.validateToken(refreshToken)) {
             throw new BadRequestException("유효하지 않은 리프레시 토큰입니다.");
@@ -72,8 +76,9 @@ public class AuthService {
         String newAccessToken = tokenProvider.createToken(authentication);
         String newRefreshToken = tokenProvider.createRefreshToken(authentication);
 
-        // Race Condition 체크 시작 : 현재 쓰레드가 재발급 로직을 수행하는 동안,
-        // 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했는지
+        //================================ Race Condition 체크 시작 =====================================
+
+        // 현재 쓰레드가 재발급 로직을 수행하는 동안 그 사이에 다른 쓰레드가 재발급 로직을 수행 하고 DB 작업 까지도 수행했는지
 
         // 재발급 로직 이후에 다시 oldTokenUserId 로 토큰 가져옴
         RefreshToken currentRedisToken = refreshTokenRepository.findById(oldTokenUserId).orElse(null);
@@ -89,7 +94,11 @@ public class AuthService {
             } else {
                 throw new BadRequestException("이미 갱신된 토큰입니다. 다시 시도해주세요.");
             }
-        } // Race Condition 체크 끝, 아래 부터는 1등 쓰레드만이 접근 가능한 코드
+        }
+
+        //================================ Race Condition 체크 끝 =====================================
+
+        // 아래의 Redis 반영은 경쟁 상태가 발생해도 상관없는 구조
 
         // Redis 업데이트 (1등 쓰레드만이 Grace Period 적중이 안되고 Race Condition 감지도 안되어져서 DB 작업 수행)
         refreshTokenRepository.save(new RefreshToken(oldTokenUserId, newRefreshToken));
@@ -99,6 +108,7 @@ public class AuthService {
                 .refreshToken(newRefreshToken)
                 .build();
 
+        // Grace_period 설정
         // 1등이 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키에 재발급한 리프레시 토큰을 value 로 설정
         // 트랜잭셔널 없으므로 즉시 반영
         redisTemplate.opsForValue().set(graceKey, tokenResponse, 10, TimeUnit.SECONDS);

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.practice.OAuth2.global.exception.BadRequestException;
 import com.practice.OAuth2.global.security.TokenProvider;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -14,6 +15,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Collections;
+import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -22,10 +24,24 @@ public class AuthService {
     private final RefreshTokenRepository refreshTokenRepository;
     private final TokenProvider tokenProvider;
 
+    private final RedisTemplate<String, Object> redisTemplate;
+
     @Transactional
     public TokenResponse reissue(String refreshToken) {
         if (refreshToken == null) {
             throw new BadRequestException("리프레시 토큰을 받지 못했습니다.");
+        }
+
+        // 방금 사용된(만료된) 토큰이지만, 10초의 유예기간 안에는 허용
+        String graceKey = "grace_period:" + refreshToken;
+
+        // 캐시에서 조회 (있으면 캐스팅해서 바로 반환)
+        TokenResponse cachedToken = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
+
+        if (cachedToken != null) {
+            // 로그를 찍어두면 디버깅에 좋습니다.
+            System.out.println(" 적중: 기존에 발급된 토큰을 반환합니다.");
+            return cachedToken;
         }
 
         if (!tokenProvider.validateToken(refreshToken)) {
@@ -57,10 +73,15 @@ public class AuthService {
         // 5. Redis 업데이트
         refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
 
-        return TokenResponse.builder()
+        TokenResponse tokenResponse = TokenResponse.builder()
                 .accessToken(newAccessToken)
                 .refreshToken(newRefreshToken)
                 .build();
+
+        // Old Token(refreshToken)으로 10초 내에 또 요청이 오면, 이 New Token(tokenResponse)을 반환
+        redisTemplate.opsForValue().set(graceKey, tokenResponse, 10, TimeUnit.SECONDS);
+
+        return tokenResponse;
     }
 
     @Transactional

--- a/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
+++ b/src/main/java/com/practice/OAuth2/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.practice.OAuth2.global.exception.BadRequestException;
 import com.practice.OAuth2.global.security.TokenProvider;
 import com.practice.OAuth2.global.security.UserPrincipal;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
@@ -17,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 import java.util.Collections;
 import java.util.concurrent.TimeUnit;
 
-@Service
+@Service @Slf4j
 @RequiredArgsConstructor
 public class AuthService {
 
@@ -32,15 +33,15 @@ public class AuthService {
             throw new BadRequestException("리프레시 토큰을 받지 못했습니다.");
         }
 
-        // 방금 사용된(만료된) 토큰이지만, 10초의 유예기간 안에는 허용
+        // 10초 유예기간 캐시저장소의 키 이름 설정 : 어떤 Old Token(파라미터로 온 refreshToken)이 요청했는지를 식별하기 위함
         String graceKey = "grace_period:" + refreshToken;
 
-        // 캐시에서 조회 (있으면 캐스팅해서 바로 반환)
+        /* 레디스 캐시저장소에 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키를 가진 캐시 엔트리가 존재한다면
+           1등이 Old Token 을 써서 재발급 했었다는 뜻 -> 이 캐시 엔트리는 재발급된 리프레시 토큰이므로 바로 이 데이터 응답,
+           캐시엔트리 유예기간 : 10초 설정 */
         TokenResponse cachedToken = (TokenResponse) redisTemplate.opsForValue().get(graceKey);
-
         if (cachedToken != null) {
-            // 로그를 찍어두면 디버깅에 좋습니다.
-            System.out.println(" 적중: 기존에 발급된 토큰을 반환합니다.");
+            log.info("Grace Period 적중");
             return cachedToken;
         }
 
@@ -70,7 +71,7 @@ public class AuthService {
         String newAccessToken = tokenProvider.createToken(authentication);
         String newRefreshToken = tokenProvider.createRefreshToken(authentication);
 
-        // 5. Redis 업데이트
+        // Redis 업데이트
         refreshTokenRepository.save(new RefreshToken(userId, newRefreshToken));
 
         TokenResponse tokenResponse = TokenResponse.builder()
@@ -78,7 +79,7 @@ public class AuthService {
                 .refreshToken(newRefreshToken)
                 .build();
 
-        // Old Token(refreshToken)으로 10초 내에 또 요청이 오면, 이 New Token(tokenResponse)을 반환
+        // 1등이 Old Token(파라미터로 온 refreshToken) 이름이 포함된 키에 재발급한 리프레시 토큰을 value 로 설정
         redisTemplate.opsForValue().set(graceKey, tokenResponse, 10, TimeUnit.SECONDS);
 
         return tokenResponse;

--- a/src/main/java/com/practice/OAuth2/global/config/RedisRepositoryConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/RedisRepositoryConfig.java
@@ -7,6 +7,7 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
@@ -31,7 +32,8 @@ public class RedisRepositoryConfig {
 
         // Key, Value 직렬화 설정 (문자열 위주로 저장하므로 StringSerializer 사용)
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
+        // value 는 유예기간 리프레시토큰용 JSON 객체
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 
         return redisTemplate;
     }

--- a/src/main/java/com/practice/OAuth2/global/config/RedissonConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/RedissonConfig.java
@@ -1,0 +1,31 @@
+package com.practice.OAuth2.global.config;
+
+import org.redisson.Redisson;
+import org.redisson.api.RedissonClient;
+import org.redisson.config.Config;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RedissonConfig {
+
+    @Value("${spring.data.redis.host}")
+    private String host;
+
+    @Value("${spring.data.redis.port}")
+    private int port;
+
+    @Bean
+    public RedissonClient redissonClient() {
+        Config config = new Config();
+
+        // Redis 주소 앞에 "redis://"
+        String address = "redis://" + host + ":" + port;
+
+        config.useSingleServer()
+                .setAddress(address);
+
+        return Redisson.create(config);
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #45 
## 💥작업 내용
<!-- 이슈에 표기한 작업/수정/추가한 내용등을 적어주세요. -->
<!-- 작업내용 사진을 올리면 더 좋습니다 (postman api test결과 등) -->
- 프런트에서 한 페이지에 여러 컴포넌트에서 재발급 API를 요청 시 리프레시 토큰 발급 동시성 문제로 Race Condition이 발생 가능
- 이를 백엔드단에서 해결
  - 리프레시토큰 redis 캐싱을 이용한 낙관적 락 으로 구현 했었는데 코드 복잡도와 버그로 인하여 redisson lock + Result Caching 방식으로 전환

테스트 완료 ( 쓰레드 20개도 동시성 해결 가능 )
<img width="870" height="644" alt="스크린샷 2025-12-11 오후 8 31 09" src="https://github.com/user-attachments/assets/435d78da-c2f6-4468-92a6-09d7978ff7b7" />

<img width="810" height="447" alt="스크린샷 2025-12-11 오후 8 36 56" src="https://github.com/user-attachments/assets/e149dcd7-fef9-4fa7-9894-61a3ad05edf2" />


## ✨참고 사항 
- 첫번째로 온 1등 쓰레드만 Redis Repository 및 Redis Cache 저장소에 접근 하여 처리 하고 결과 응답을 Result Caching
  - 나머지 쓰레들은 lock 전에 Cache hit 되거나 락 풀리자마자 DB 접근 이전 Double-Checked Locking에서 Cache hit


