### PR TITLE
 mybatis 환경 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 	implementation 'org.springframework.boot:spring-boot-starter-websocket'
 	implementation 'mysql:mysql-connector-java:8.0.26'
+    implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
@@ -22,4 +22,17 @@ public class AttractionController {
         List<AttractionResponse> results = attractionService.searchAttractions(keyword);
         return ResponseEntity.ok(results);
     }
+
+
+
+
+    // MyBatis 연결 테스트용
+    // 접속 주소: http://localhost:8080/api/attractions/mybatis-test
+    @GetMapping("/mybatis-test")
+    public ResponseEntity<List<AttractionResponse>> testMyBatis() {
+        List<AttractionResponse> results = attractionService.getAttractionListTest();
+        return ResponseEntity.ok(results);
+    }
+
+
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse.java
@@ -1,9 +1,14 @@
 package com.practice.OAuth2.domain.attraction.dto;
 
 import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import lombok.AllArgsConstructor;
+import lombok.Data;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
-@Getter
+@Data              // 1. Getter, Setter 다 만들어줌 (마이바티스가 데이터 넣을 때 필요)
+@NoArgsConstructor // 2. 빈 생성자 만들어줌 (마이바티스가 객체 생성할 때 필요)
+@AllArgsConstructor // 3. 모든 필드 생성자 만들어줌
 public class AttractionResponse {
     private Integer attractionId;
     private String title;         // 장소명

--- a/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
@@ -1,0 +1,12 @@
+package com.practice.OAuth2.domain.attraction.mapper;
+
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse; // [중요] DTO 임포트
+import org.apache.ibatis.annotations.Mapper;
+import java.util.List;
+
+@Mapper
+public interface AttractionMapper {
+
+
+    List<AttractionResponse> findAllAttractions();
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
@@ -1,6 +1,7 @@
 package com.practice.OAuth2.domain.attraction.service;
 
 import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.mapper.AttractionMapper;
 import com.practice.OAuth2.domain.attraction.repository.AttractionRepository;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class AttractionService {
     private final AttractionRepository attractionRepository;
 
+    private final AttractionMapper attractionMapper;
+
     public List<AttractionResponse> searchAttractions(String keyword) {
         if (keyword == null || keyword.trim().isEmpty()) {
             return List.of(); // 검색어 없으면 빈 리스트
@@ -24,4 +27,12 @@ public class AttractionService {
                 .map(AttractionResponse::new)
                 .collect(Collectors.toList());
     }
+
+    //  MyBatis 테스트용 메서드
+    public List<AttractionResponse> getAttractionListTest() {
+
+        return attractionMapper.findAllAttractions();
+    }
+
+
 }

--- a/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig {
                         "/**.css",
                         "/**.js")
                         .permitAll()
-                    .requestMatchers( "/api/auth/**", "/oauth2/**")
+                    .requestMatchers( "/api/auth/**", "/oauth2/**","/api/attractions/**")
                         .permitAll()
                     .requestMatchers("/ws/**")
                         .permitAll()

--- a/src/main/resources/mapper/attraction/AttractionMapper.xml
+++ b/src/main/resources/mapper/attraction/AttractionMapper.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
+
+<mapper namespace="com.practice.OAuth2.domain.attraction.mapper.AttractionMapper">
+
+    <select id="findAllAttractions" resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse">
+        SELECT
+        attr_id      AS attractionId,
+        title,
+        addr1        AS address,
+        first_image1 AS imageUrl,
+        latitude,
+        longitude
+        FROM attractions
+        LIMIT 10
+    </select>
+
+</mapper>


### PR DESCRIPTION
## 📌관련 이슈
- Closes: #52
## 💥작업 내용
- MyBatis 의존성 추가 및 설정 완료 (build.gradle)
- Attraction 기초 조회 Mapper 구현 (AttractionMapper.xml 및 인터페이스 정의)
- DTO 매핑 구조 개선: AttractionResponse DTO에 @Data, @NoArgsConstructor, @AllArgsConstructor 어노테이션 추가하여 MyBatis 자동 매핑 환경 조성.
- Security 설정 업데이트: 테스트를 위해 /api/attractions/** 경로에 permitAll() 설정 적용
- 테스트 엔드포인트 구현: /api/attractions/mybatis-test 를 통해 DB 연결 및 데이터 조회 확인
-application.yml파일 추가 사항은 노션에 따로 추가
## ✨참고 사항 
- 


