### PR TITLE
Feature/#56 지도검색 geohash클러스터링 api

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
@@ -1,14 +1,13 @@
 package com.practice.OAuth2.domain.attraction.controller;
 
+import com.practice.OAuth2.domain.attraction.dto.AttractionRequest;
 import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse2;
 import com.practice.OAuth2.domain.attraction.service.AttractionService;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -23,16 +22,25 @@ public class AttractionController {
         return ResponseEntity.ok(results);
     }
 
-
+    @GetMapping("/map") //
+    public ResponseEntity<List<AttractionResponse2>> getMapMarkers(
+            @ModelAttribute AttractionRequest request
+    ) {
+        List<AttractionResponse2> result = attractionService.getMapMarkers(request);
+        return ResponseEntity.ok(result);
+    }
 
 
     // MyBatis 연결 테스트용
-    // 접속 주소: http://localhost:8080/api/attractions/mybatis-test
-    @GetMapping("/mybatis-test")
+    // 접속 주소: http://localhost:8080/api/attractions/map/mybatis-test
+    @GetMapping("/map/mybatis-test")
     public ResponseEntity<List<AttractionResponse>> testMyBatis() {
         List<AttractionResponse> results = attractionService.getAttractionListTest();
         return ResponseEntity.ok(results);
     }
+
+
+
 
 
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
@@ -1,0 +1,38 @@
+package com.practice.OAuth2.domain.attraction.dto;
+
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.AllArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttractionRequest {
+
+    // 1. 필수 파라미터 (화면 좌표 & 줌 레벨)
+    private Integer zoomLevel;      // 1~13
+    private Double southWestLat;
+    private Double southWestLng;
+    private Double northEastLat;
+    private Double northEastLng;
+
+    // 2. 선택 파라미터 (필터링)
+    private Integer sido;           // 시/도 코드
+    private Integer guguns;         // 구/군 코드
+    private Integer contenttype;    // 관광지 타입
+    private String keyword;         // 검색어
+
+    // 3. [중요] MyBatis가 호출할 로직 (줌 레벨 -> Geohash 자릿수 변환)
+    // XML에서 #{precision}을 쓰면 이 메서드가 실행됩니다.
+    public Integer getPrecision() {
+        if (this.zoomLevel == null) return 5; // 기본값 방어
+
+        // 숫자가 클수록 넓은 화면(13) -> 5자리 (동네)
+        // 숫자가 작을수록 좁은 화면(1) -> 6자리 (블록)
+        if (this.zoomLevel >= 8) {
+            return 3;
+        } else {
+            return 6;
+        }
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
@@ -17,7 +17,7 @@ public class AttractionRequest {
     private Double northEastLng;
 
     // 2. 선택 파라미터 (필터링)
-    private Integer sido;           // 시/도 코드
+    private Integer sido;            // 시/도 코드
     private Integer guguns;         // 구/군 코드
     private Integer contenttype;    // 관광지 타입
     private String keyword;         // 검색어
@@ -29,10 +29,14 @@ public class AttractionRequest {
 
         // 숫자가 클수록 넓은 화면(13) -> 5자리 (동네)
         // 숫자가 작을수록 좁은 화면(1) -> 6자리 (블록)
-        if (this.zoomLevel >= 8) {
+        if (this.zoomLevel >= 11){
             return 3;
-        } else {
+        }else if(this.zoomLevel >= 8){
+            return 4;
+        }else if(this.zoomLevel >= 6){
             return 6;
+        }else{
+            return 7;
         }
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse2.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionResponse2.java
@@ -1,0 +1,38 @@
+package com.practice.OAuth2.domain.attraction.dto;
+
+import com.practice.OAuth2.domain.attraction.entity.Attraction;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttractionResponse2 {
+
+    private Integer attractionId; // 클러스터면 0
+    private Integer count;        // 1이면 마커, 2이상이면 클러스터
+    private String title;
+    private Double latitude;
+    private Double longitude;
+
+    // 상세 정보 (마커일 때만 존재)
+    private String address;
+    private String imageUrl;
+
+    // Entity -> DTO 변환용 생성자 (낱개 마커용)
+    public AttractionResponse2(Attraction attraction) {
+        this.attractionId = attraction.getAttrId();
+        this.title = attraction.getTitle();
+        this.address = attraction.getAddr1();
+        this.imageUrl = attraction.getFirstImage1();
+        this.count = 1; // 낱개는 무조건 1
+
+        if (attraction.getLatitude() != null) {
+            this.latitude = attraction.getLatitude().doubleValue();
+        }
+        if (attraction.getLongitude() != null) {
+            this.longitude = attraction.getLongitude().doubleValue();
+        }
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
@@ -1,12 +1,24 @@
 package com.practice.OAuth2.domain.attraction.mapper;
 
-import com.practice.OAuth2.domain.attraction.dto.AttractionResponse; // [중요] DTO 임포트
+import com.practice.OAuth2.domain.attraction.dto.AttractionRequest;
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse2;
 import org.apache.ibatis.annotations.Mapper;
+
 import java.util.List;
 
 @Mapper
 public interface AttractionMapper {
 
+    // 1. 전체 개수 조회
+    int countAttractions(AttractionRequest request);
 
+    // 2. 클러스터링 조회
+    List<AttractionResponse2> findClusteredAttractions(AttractionRequest request);
+
+    // 3. 낱개 마커 조회
+    List<AttractionResponse2> findRawAttractions(AttractionRequest request);
+
+    // 테스트용
     List<AttractionResponse> findAllAttractions();
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
@@ -1,6 +1,8 @@
 package com.practice.OAuth2.domain.attraction.service;
 
+import com.practice.OAuth2.domain.attraction.dto.AttractionRequest;
 import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
+import com.practice.OAuth2.domain.attraction.dto.AttractionResponse2;
 import com.practice.OAuth2.domain.attraction.mapper.AttractionMapper;
 import com.practice.OAuth2.domain.attraction.repository.AttractionRepository;
 import java.util.List;
@@ -28,11 +30,35 @@ public class AttractionService {
                 .collect(Collectors.toList());
     }
 
+
+    @Transactional(readOnly = true)
+    public List<AttractionResponse2> getMapMarkers(AttractionRequest request) {
+
+        // 1. 현재 화면(Viewport) 안에 데이터가 총 몇 개인지 확인
+        int totalCount = attractionMapper.countAttractions(request);
+
+        // 2. 전략 선택 (Strategy Pattern)
+        if (totalCount < 50) {
+            // [CASE A] 50개 미만 -> 낱개 조회 (사진, 주소 포함)
+            // (안전장치 LIMIT 100 걸려있음)
+            return attractionMapper.findRawAttractions(request);
+        } else {
+            // [CASE B] 50개 이상 -> 클러스터링 조회 (껍데기만, 개수 위주)
+            // (request.getPrecision()이 내부적으로 계산됨)
+            return attractionMapper.findClusteredAttractions(request);
+        }
+    }
+
+
+
+
     //  MyBatis 테스트용 메서드
     public List<AttractionResponse> getAttractionListTest() {
 
         return attractionMapper.findAllAttractions();
     }
+
+
 
 
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
@@ -34,23 +34,36 @@ public class AttractionService {
     @Transactional(readOnly = true)
     public List<AttractionResponse2> getMapMarkers(AttractionRequest request) {
 
-        // 1. 현재 화면(Viewport) 안에 데이터가 총 몇 개인지 확인
+        // 1. [유효성 검사] 4개 중 최소 1개는 값이 있어야 함!
+        if (!hasAtLeastOneCondition(request)) {
+            throw new IllegalArgumentException("검색 조건(시도, 구군, 검색어, 컨텐츠타입) 중 하나는 필수입니다.");
+        }
+
+        // 2. 전체 개수 조회
         int totalCount = attractionMapper.countAttractions(request);
 
-        // 2. 전략 선택 (Strategy Pattern)
-        if (totalCount < 50) {
-            // [CASE A] 50개 미만 -> 낱개 조회 (사진, 주소 포함)
-            // (안전장치 LIMIT 100 걸려있음)
+        // 3. 개수에 따른 로직 분기 (기존 코드)
+        if (totalCount < 200) {
             return attractionMapper.findRawAttractions(request);
         } else {
-            // [CASE B] 50개 이상 -> 클러스터링 조회 (껍데기만, 개수 위주)
-            // (request.getPrecision()이 내부적으로 계산됨)
             return attractionMapper.findClusteredAttractions(request);
         }
     }
 
+    private boolean hasAtLeastOneCondition(AttractionRequest req) {
 
+        // 1. int 타입들 (sido, guguns, contenttype) -> Integer로 가정하고 null 체크
+        // 만약 DTO가 원시타입 int라면 "req.getSido() != 0" 으로 고쳐야 합니다.
+        boolean hasSido = req.getSido() != null;
+        boolean hasGuguns = req.getGuguns() != null;
+        boolean hasContentType = req.getContenttype() != null;
 
+        // 2. String 타입 (keyword) -> null 아니고, 빈 문자열("") 아니고, 공백(" ")도 아닌지 체크
+        boolean hasKeyword = req.getKeyword() != null && !req.getKeyword().trim().isEmpty();
+
+        // 3. 넷 중 하나라도 true면 통과 (OR 연산)
+        return hasSido || hasGuguns || hasContentType || hasKeyword;
+    }
 
     //  MyBatis 테스트용 메서드
     public List<AttractionResponse> getAttractionListTest() {

--- a/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
+++ b/src/main/java/com/practice/OAuth2/global/config/SecurityConfig.java
@@ -102,7 +102,7 @@ public class SecurityConfig {
                         "/**.css",
                         "/**.js")
                         .permitAll()
-                    .requestMatchers( "/api/auth/**", "/oauth2/**","/api/attractions/**")
+                    .requestMatchers( "/api/auth/**", "/oauth2/**","/api/attractions/map/**","/api/attractions/map")
                         .permitAll()
                     .requestMatchers("/ws/**")
                         .permitAll()

--- a/src/main/resources/mapper/attraction/AttractionMapper.xml
+++ b/src/main/resources/mapper/attraction/AttractionMapper.xml
@@ -4,16 +4,65 @@
 
 <mapper namespace="com.practice.OAuth2.domain.attraction.mapper.AttractionMapper">
 
-    <select id="findAllAttractions" resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse">
+    <sql id="searchConditions">
+        <where>
+            latitude BETWEEN #{southWestLat} AND #{northEastLat}
+            AND longitude BETWEEN #{southWestLng} AND #{northEastLng}
+
+            <if test="sido != null"> AND area_code = #{sido} </if>
+            <if test="guguns != null"> AND si_gun_gu_code = #{guguns} </if>
+            <if test="contenttype != null"> AND content_type_id = #{contenttype} </if>
+            <if test="keyword != null and keyword != ''">
+                AND MATCH(title) AGAINST(#{keyword} IN BOOLEAN MODE)
+            </if>
+        </where>
+    </sql>
+
+    <select id="countAttractions"
+            parameterType="com.practice.OAuth2.domain.attraction.dto.AttractionRequest"
+            resultType="int">
+        SELECT COUNT(*) FROM attractions
+        <include refid="searchConditions" />
+    </select>
+
+    <select id="findClusteredAttractions"
+            parameterType="com.practice.OAuth2.domain.attraction.dto.AttractionRequest"
+            resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse2">
+        SELECT
+        0                                AS attractionId,
+        COUNT(*)                         AS count,
+        AVG(latitude)                    AS latitude,
+        AVG(longitude)                   AS longitude,
+        MAX(title)                       AS title,
+        NULL                             AS address,
+        NULL                             AS imageUrl
+        FROM attractions
+        <include refid="searchConditions" />
+        GROUP BY LEFT(geohash, #{precision})
+    </select>
+
+    <select id="findRawAttractions"
+            parameterType="com.practice.OAuth2.domain.attraction.dto.AttractionRequest"
+            resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse2">
         SELECT
         attr_id      AS attractionId,
-        title,
+        1            AS count,
+        latitude     AS latitude,
+        longitude    AS longitude,
+        title        AS title,
         addr1        AS address,
-        first_image1 AS imageUrl,
-        latitude,
-        longitude
+        first_image1 AS imageUrl
         FROM attractions
-        LIMIT 10
+        <include refid="searchConditions" />
+        LIMIT 100
+    </select>
+
+
+
+
+    <select id="findAllAttractions" resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse2">
+        SELECT attr_id AS attractionId, title, addr1 AS address, first_image1 AS imageUrl, latitude, longitude, 1 as count
+        FROM attractions LIMIT 10
     </select>
 
 </mapper>

--- a/src/main/resources/mapper/attraction/AttractionMapper.xml
+++ b/src/main/resources/mapper/attraction/AttractionMapper.xml
@@ -29,13 +29,20 @@
             parameterType="com.practice.OAuth2.domain.attraction.dto.AttractionRequest"
             resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse2">
         SELECT
-        0                                AS attractionId,
+        -- count가 1이면 attr_id를, 2 이상이면 0 (클러스터 ID) 반환
+        CASE WHEN COUNT(*) = 1 THEN MAX(attr_id) ELSE 0 END AS attractionId,
+
         COUNT(*)                         AS count,
         AVG(latitude)                    AS latitude,
         AVG(longitude)                   AS longitude,
         MAX(title)                       AS title,
-        NULL                             AS address,
-        NULL                             AS imageUrl
+
+        -- -----------------------------------------------------------------------------------
+        -- 💡 [핵심 수정] count가 1일 때만 상세 정보를 채우고, 2 이상일 때는 NULL을 반환합니다.
+        -- -----------------------------------------------------------------------------------
+        CASE WHEN COUNT(*) = 1 THEN MAX(addr1) ELSE NULL END AS address,
+        CASE WHEN COUNT(*) = 1 THEN MAX(first_image1) ELSE NULL END AS imageUrl
+
         FROM attractions
         <include refid="searchConditions" />
         GROUP BY LEFT(geohash, #{precision})
@@ -54,7 +61,7 @@
         first_image1 AS imageUrl
         FROM attractions
         <include refid="searchConditions" />
-        LIMIT 100
+        LIMIT 250
     </select>
 
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #56
## 💥작업 내용
1. 지도 검색 및 동적 클러스터링 구현 (/attractions/map)

조회 전략 분기 (Threshold: 200개):

뷰포트 내 데이터가 200개 미만일 경우: 클러스터링 없이 전체 낱개 마커 반환 (findRawAttractions)

뷰포트 내 데이터가 200개 이상일 경우: Geohash 기반 클러스터링 수행 (findClusteredAttractions)

2. 클러스터링 쿼리 최적화 (Mapper)

단일 마커 정보 보존 (CASE WHEN):

클러스터링 결과 그룹 내 개수(COUNT)가 1개인 경우: AVG 대신 실제 attr_id, address, imageUrl 등 상세 정보를 반환하여 일반 마커처럼 동작하도록 처리

개수가 2개 이상인 경우: attractionId를 0으로, 상세 정보를 NULL로 반환하여 클러스터 마커로 동작

3. 검색 조건 유효성 검증

필수 파라미터 체크: 시도, 구군, 콘텐츠타입, 검색어 중 최소 1개 이상의 조건이 포함되어야만 쿼리를 실행하도록 방어 로직 추가 (hasAtLeastOneCondition)

조건 미충족 시 IllegalArgumentException 예외 처리

4. DB 성능 튜닝

인덱스 추가: idx_lat_lon (위경도 복합 인덱스) 추가로 뷰포트 검색 속도 개선

Ngram Parser: 한글 부분 검색 지원을 위해 FULLTEXT INDEX에 Ngram 파서 적용
## ✨참고 사항 
- DB 스키마 변경 필수: 공유된 structure.sql을 실행하여 인덱스가 적용된 테이블로 갱신해주세요. (데이터는 기존 4차 덤프 사용 가능)
- 클러스터링 쿼리 하나로 단일 마커와 그룹 마커를 동시에 처리하여 로직을 단순화했습니다.


