### PR TITLE
지도 사이드바 장소 조회 api 개발

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/controller/AttractionController.java
@@ -31,6 +31,17 @@ public class AttractionController {
     }
 
 
+    @GetMapping("/map/sidebar")
+    public ResponseEntity<com.practice.OAuth2.domain.attraction.dto.AttractionSliceResponse> getSidebarList(
+            @ModelAttribute AttractionRequest request
+    ) {
+        // 페이지네이션 로직 호출
+        var result = attractionService.getSidebarList(request);
+        return ResponseEntity.ok(result);
+    }
+
+
+
     // MyBatis 연결 테스트용
     // 접속 주소: http://localhost:8080/api/attractions/map/mybatis-test
     @GetMapping("/map/mybatis-test")

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionRequest.java
@@ -9,26 +9,32 @@ import lombok.AllArgsConstructor;
 @AllArgsConstructor
 public class AttractionRequest {
 
-    // 1. 필수 파라미터 (화면 좌표 & 줌 레벨)
+    // (화면 좌표 & 줌 레벨)
     private Integer zoomLevel;      // 1~13
     private Double southWestLat;
     private Double southWestLng;
     private Double northEastLat;
     private Double northEastLng;
 
-    // 2. 선택 파라미터 (필터링)
+
     private Integer sido;            // 시/도 코드
     private Integer guguns;         // 구/군 코드
     private Integer contenttype;    // 관광지 타입
     private String keyword;         // 검색어
 
-    // 3. [중요] MyBatis가 호출할 로직 (줌 레벨 -> Geohash 자릿수 변환)
-    // XML에서 #{precision}을 쓰면 이 메서드가 실행됩니다.
+
+    // [추가] 페이지네이션 필드
+    private Integer page = 0;  // 기본값 0페이지
+    private Integer size = 20; // 기본값 20개
+
+
+
+
+    // XML에서 #{precision}을 쓰면 이 메서드가 실행
     public Integer getPrecision() {
         if (this.zoomLevel == null) return 5; // 기본값 방어
 
-        // 숫자가 클수록 넓은 화면(13) -> 5자리 (동네)
-        // 숫자가 작을수록 좁은 화면(1) -> 6자리 (블록)
+
         if (this.zoomLevel >= 11){
             return 3;
         }else if(this.zoomLevel >= 8){
@@ -38,5 +44,19 @@ public class AttractionRequest {
         }else{
             return 7;
         }
+    }
+
+
+
+    // [추가] 페이지네이션
+    public int getOffset() {
+        if (page == null || page < 0) page = 0;
+        if (size == null || size <= 0) size = 20;
+        return page * size;
+    }
+
+    public int getLimit() {
+        if (size == null) size = 20;
+        return size + 1;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionSliceResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/dto/AttractionSliceResponse.java
@@ -1,0 +1,15 @@
+package com.practice.OAuth2.domain.attraction.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import java.util.List;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class AttractionSliceResponse {
+    private List<AttractionResponse2> attractions; // 목록 데이터
+    private boolean hasNext;                       // 다음 페이지 존재 여부
+    private int nowPage;                           // 현재 페이지 번호
+}

--- a/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/mapper/AttractionMapper.java
@@ -21,4 +21,9 @@ public interface AttractionMapper {
 
     // 테스트용
     List<AttractionResponse> findAllAttractions();
+
+    //페이지네이션
+    List<AttractionResponse2> findSidebarList(AttractionRequest request);
 }
+
+

--- a/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/service/AttractionService.java
@@ -49,29 +49,50 @@ public class AttractionService {
             return attractionMapper.findClusteredAttractions(request);
         }
     }
-
+    //검색 조건 유효성 검사 메서드
     private boolean hasAtLeastOneCondition(AttractionRequest req) {
-
-        // 1. int 타입들 (sido, guguns, contenttype) -> Integer로 가정하고 null 체크
-        // 만약 DTO가 원시타입 int라면 "req.getSido() != 0" 으로 고쳐야 합니다.
         boolean hasSido = req.getSido() != null;
         boolean hasGuguns = req.getGuguns() != null;
         boolean hasContentType = req.getContenttype() != null;
 
-        // 2. String 타입 (keyword) -> null 아니고, 빈 문자열("") 아니고, 공백(" ")도 아닌지 체크
         boolean hasKeyword = req.getKeyword() != null && !req.getKeyword().trim().isEmpty();
 
-        // 3. 넷 중 하나라도 true면 통과 (OR 연산)
         return hasSido || hasGuguns || hasContentType || hasKeyword;
     }
 
-    //  MyBatis 테스트용 메서드
-    public List<AttractionResponse> getAttractionListTest() {
 
-        return attractionMapper.findAllAttractions();
+
+    //사이드바 리스트
+    @Transactional(readOnly = true)
+    public com.practice.OAuth2.domain.attraction.dto.AttractionSliceResponse getSidebarList(AttractionRequest request) {
+
+        // 1. 유효성 검사 (검색 조건 없으면 빈 리스트 반환)
+        if (!hasAtLeastOneCondition(request)) {
+            // 조건이 없으면 빈 결과 반환
+            return new com.practice.OAuth2.domain.attraction.dto.AttractionSliceResponse(
+                    java.util.Collections.emptyList(), false, request.getPage());
+        }
+
+        // 2. DB 조회 (요청 사이즈보다 1개 더 가져오도록 XML에서 설정)
+        List<AttractionResponse2> result = attractionMapper.findSidebarList(request);
+
+        // 3. hasNext 판단 로직
+        boolean hasNext = false;
+        if (result.size() > request.getSize()) {
+            hasNext = true;
+            result.remove(result.size() - 1); // 확인용으로 가져온 마지막 1개 제거
+        }
+
+        // 4. 결과 반환
+        return new com.practice.OAuth2.domain.attraction.dto.AttractionSliceResponse(
+                result, hasNext, request.getPage());
     }
 
 
 
+    //  MyBatis 테스트용 메서드
+    public List<AttractionResponse> getAttractionListTest() {
+        return attractionMapper.findAllAttractions();
+    }
 
 }

--- a/src/main/resources/mapper/attraction/AttractionMapper.xml
+++ b/src/main/resources/mapper/attraction/AttractionMapper.xml
@@ -38,7 +38,7 @@
         MAX(title)                       AS title,
 
         -- -----------------------------------------------------------------------------------
-        -- 💡 [핵심 수정] count가 1일 때만 상세 정보를 채우고, 2 이상일 때는 NULL을 반환합니다.
+        -- count가 1일 때만 상세 정보를 채우고, 2 이상일 때는 NULL을 반환
         -- -----------------------------------------------------------------------------------
         CASE WHEN COUNT(*) = 1 THEN MAX(addr1) ELSE NULL END AS address,
         CASE WHEN COUNT(*) = 1 THEN MAX(first_image1) ELSE NULL END AS imageUrl
@@ -72,4 +72,25 @@
         FROM attractions LIMIT 10
     </select>
 
+
+
+    <select id="findSidebarList"
+            parameterType="com.practice.OAuth2.domain.attraction.dto.AttractionRequest"
+            resultType="com.practice.OAuth2.domain.attraction.dto.AttractionResponse2">
+        SELECT
+        attr_id      AS attractionId,
+        1            AS count,
+        latitude     AS latitude,
+        longitude    AS longitude,
+        title        AS title,
+        addr1        AS address,
+        first_image1 AS imageUrl
+        FROM attractions
+        <include refid="searchConditions" />
+
+        ORDER BY like_count DESC, view_count DESC, attr_id DESC
+
+        LIMIT #{limit}
+        OFFSET #{offset}
+    </select>
 </mapper>


### PR DESCRIPTION
## 📌관련 이슈
- closed: #61
## 💥작업 내용
- 사이드바 장소 목록 API 구현 (/api/attractions/map/sidebar)
   뷰포트 내 장소를 **좋아요순(1순위) -> 조회수순(2순위)**으로 정렬하여 반환
- 무한 스크롤(Infinite Scroll) 페이지네이션 적용
- 기존 검색 로직 재사용
## ✨참고 사항 
- API 동작 방식: 검색 조건(키워드, 콘텐츠 타 등)이 하나라도 포함되어야 데이터를 반환하며, 조건이 없으면 빈 리스트를 반환


