### PR TITLE
Feature : s3 설정 및 planfolder image 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'mysql:mysql-connector-java:8.0.26'
     implementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter:3.0.3'
     implementation 'org.jsoup:jsoup:1.16.1'
+    implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
@@ -20,17 +20,13 @@ public class PlanCreateRequest {
     @NonNull
     private LocalDate endDate;
 
-    @NonNull
-    private String planImageUrl;
-
-    // DTO -> Entity 변환 메서드 (서비스 로직 단축용)
-    public Plan toEntity() {
-        return Plan.builder()
-                .title(this.title)
-                .startDate(this.startDate)
-                .endDate(this.endDate)
-                .planImageUrl(this.planImageUrl)
-                .build();
-        // inviteCode는 엔티티 생성자(Builder) 안에서 자동 생성
-    }
+//    // DTO -> Entity 변환 메서드 (서비스 로직 단축용)
+//    public Plan toEntity() {
+//        return Plan.builder()
+//                .title(this.title)
+//                .startDate(this.startDate)
+//                .endDate(this.endDate)
+//                .build();
+//        // inviteCode는 엔티티 생성자(Builder) 안에서 자동 생성
+//    }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/Plan.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/Plan.java
@@ -62,9 +62,10 @@ public class Plan extends BaseEntity {
         this.inviteCode = UUID.randomUUID().toString();
     }
 
-    public void update(String title, LocalDate startDate, LocalDate endDate) {
+    public void update(String title, LocalDate startDate, LocalDate endDate, String planImageUrl) {
         this.title = title;
         this.startDate = startDate;
         this.endDate = endDate;
+        this.planImageUrl = planImageUrl;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
@@ -125,8 +125,11 @@ public class PlanService {
 
         // 권한 체크
 
+        // 기간 변경시 사진도 변경
+        String newSeasonalImageUrl = getSeasonalImageUrl(request.getStartDate());
+
         // 데이터 수정
-        plan.update(request.getTitle(), request.getStartDate(), request.getEndDate());
+        plan.update(request.getTitle(), request.getStartDate(), request.getEndDate(), newSeasonalImageUrl);
 
         // [STOMP] PLAN_UPDATED 알림 전송
         // 변경된 Plan 정보를 모두에게 발행

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
@@ -11,6 +11,8 @@ import com.practice.OAuth2.domain.plan.repository.PlanMemberRepository;
 import com.practice.OAuth2.domain.plan.repository.PlanRepository;
 import com.practice.OAuth2.domain.user.entity.User;
 import com.practice.OAuth2.domain.user.repository.UserRepository;
+
+import java.time.LocalDate;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -29,13 +31,25 @@ public class PlanService {
     // STOMP 메시지 전송용 (드래그 앤 드롭에 쓰임)
     private final SimpMessagingTemplate messagingTemplate;
 
+    private static final String SPRING_IMAGE = "https://gm-public-bucket.s3.ap-northeast-2.amazonaws.com/spring.png";
+    private static final String SUMMER_IMAGE = "https://gm-public-bucket.s3.ap-northeast-2.amazonaws.com/summer.png";
+    private static final String AUTUMN_IMAGE = "https://gm-public-bucket.s3.ap-northeast-2.amazonaws.com/autumn.png";
+    private static final String WINTER_IMAGE = "https://gm-public-bucket.s3.ap-northeast-2.amazonaws.com/winter.png";
+
     // 여행 생성
     @Transactional
     public PlanResponse createPlan(PlanCreateRequest request, Long userId){
         User user = userRepository.findById(userId)
                 .orElseThrow(()-> new IllegalArgumentException("존재하지 않는 사용자"));
 
-        Plan plan = request.toEntity();
+        String seasonalImageUrl = getSeasonalImageUrl(request.getStartDate());
+
+        Plan plan = Plan.builder()
+                .title(request.getTitle())
+                .startDate(request.getStartDate())
+                .endDate(request.getEndDate())
+                .planImageUrl(seasonalImageUrl) // 선정된 이미지 저장
+                .build();
         planRepository.save(plan);
 
         // 최초 등록
@@ -49,6 +63,20 @@ public class PlanService {
 
         // inviteCode가 포함된 응답이 나감
         return new PlanResponse(plan);
+    }
+
+    private String getSeasonalImageUrl(LocalDate startDate) {
+        int month = startDate.getMonthValue(); // 1~12
+
+        if (month >= 3 && month <= 5) {
+            return SPRING_IMAGE; // 3, 4, 5월 -> 봄
+        } else if (month >= 6 && month <= 8) {
+            return SUMMER_IMAGE; // 6, 7, 8월 -> 여름
+        } else if (month >= 9 && month <= 11) {
+            return AUTUMN_IMAGE; // 9, 10, 11월 -> 가을
+        } else {
+            return WINTER_IMAGE; // 12, 1, 2월 -> 겨울
+        }
     }
 
     // 친구 초대

--- a/src/main/java/com/practice/OAuth2/global/config/S3Config.java
+++ b/src/main/java/com/practice/OAuth2/global/config/S3Config.java
@@ -1,0 +1,33 @@
+package com.practice.OAuth2.global.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class S3Config {
+
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    public AmazonS3Client amazonS3Client() {
+        BasicAWSCredentials credentials = new BasicAWSCredentials(accessKey, secretKey);
+
+        return (AmazonS3Client) AmazonS3ClientBuilder
+                .standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(credentials))
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌관련 이슈
- closed: #82 
## 💥작업 내용
- s3 라이브러리 설정 및 설정파일 추가
- 엔티티 생성 로직 이동[Entity -> Service]
- 4계절 사진 aws에서 등록 후 서비스에 하드코딩
- 기간에 따른 4계절 사진 객체에 추가하도록 구현 
- 기간 수정시 사진 바뀌도록 기능 추가 구현
- 기간에 따른 계절사진 불러오기 api 테스트(여행 계획 생성)
  
<img width="863" height="596" alt="봄" src="https://github.com/user-attachments/assets/69c869a6-86fb-4bbc-ae93-4ee0d2a4fdd8" />

## ✨참고 사항 
- 3, 4, 5 : 봄
- 6, 7, 8 : 여름
- 9, 10, 11 : 가을
- 12, 1, 2 : 겨울


