### PR TITLE
Feature : memo 순서 변경 로직 구현

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/MemoController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/MemoController.java
@@ -12,6 +12,8 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import java.util.List;
+
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/memos") // ★ 여기를 주목! 모든 요청의 시작점
@@ -41,6 +43,15 @@ public class MemoController {
     @DeleteMapping("/{memoId}")
     public ResponseEntity<Void> deleteMemo(@PathVariable Long memoId) {
         memoService.deleteMemo(memoId);
+        return ResponseEntity.ok().build();
+    }
+
+    @PatchMapping("/{blockId}/order")
+    public ResponseEntity<Void> reorderMemos(
+            @PathVariable Long blockId,
+            @RequestBody List<Long> memoIds
+    ) {
+        memoService.reorderMemos(blockId, memoIds);
         return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/Memo.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/Memo.java
@@ -45,9 +45,17 @@ public class Memo extends BaseEntity {
     @Column(length = 20)
     private String type;
 
+    @Column(name = "order_index")
+    private Integer orderIndex;
+
     public void update(String content, String linkUrl, String type) {
         this.content = content;
         this.linkUrl = linkUrl;
         this.type = type;
+    }
+
+    // 메모 순서 변경
+    public void changeOrder(Integer orderIndex) {
+        this.orderIndex = orderIndex;
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/MemoRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/MemoRepository.java
@@ -2,10 +2,16 @@ package com.practice.OAuth2.domain.plan.repository;
 
 import com.practice.OAuth2.domain.plan.entity.Memo;
 import java.util.List;
+
+import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface MemoRepository extends JpaRepository<Memo, Long> {
-    // 스케줄 블럭에 달린 메모 조회
-    // findByScheduleBlock_BlockId 고민
-    List<Memo> findAllByScheduleBlock_BlockId(Long blockId);
+    // 특정 블록에 달린 메모 개수 세기
+    // 용도: 새 메모 생성 시 마지막 순서(orderIndex)를 구하기 위함
+    Integer countByScheduleBlock(ScheduleBlock scheduleBlock);
+
+    // 특정 블록의 모든 메모 조회 (순서대로 정렬)
+    // 용도: 순서 변경(Reorder) 로직이나, 화면에 뿌려줄 때 사용
+    List<Memo> findAllByScheduleBlockOrderByOrderIndexAsc(ScheduleBlock scheduleBlock);
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/MemoService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/MemoService.java
@@ -7,8 +7,11 @@ import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
 import com.practice.OAuth2.domain.plan.repository.MemoRepository;
 import com.practice.OAuth2.domain.plan.repository.ScheduleBlockRepository;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
@@ -38,10 +41,15 @@ public class MemoService {
         if (!tryLock(lockKey)) throw new IllegalStateException("잠시 후 시도해주세요.");
 
         try {
+
+            // 기존에 3개(0, 1, 2)가 있다면 count는 3이다
+            Integer nextOrder = memoRepository.countByScheduleBlock(block);
+
             Memo memo = Memo.builder()
                     .scheduleBlock(block)
                     .content(request.getContent())
                     .linkUrl(request.getLinkUrl())
+                    .orderIndex(nextOrder)
                     .type(request.getType())
                     .build();
 
@@ -91,6 +99,46 @@ public class MemoService {
 
             // [STOMP] MEMO_DELETED (삭제된 ID와 소속 블록 ID 전송)
             sendStompMessage(planId, "MEMO_DELETED", new MemoResponse(memo));
+
+        } finally {
+            unlock(lockKey);
+        }
+    }
+
+    // 메모 순서 이동
+    public void reorderMemos(Long blockId, List<Long> memoIds) {
+        ScheduleBlock block = scheduleBlockRepository.findById(blockId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 블록입니다."));
+
+        String lockKey = LOCK_PREFIX + block.getPlan().getPlanId();
+
+        if (!tryLock(lockKey)) throw new IllegalStateException("잠시 후 시도해주세요.");
+
+        try {
+            // 1. 해당 블록의 모든 메모 가져오기
+            List<Memo> memos = memoRepository.findAllByScheduleBlockOrderByOrderIndexAsc(block);
+
+            // 2. ID 리스트 순서대로 orderIndex 재설정
+            // (ID 리스트: [3, 1, 2])
+
+            for ( int i = 0; i < memoIds.size(); i++) {
+                Long targetId = memoIds.get(i);
+
+                final int index = i;
+                // 메모 리스트에서 해당 ID 찾아서 순서 업데이트
+                memos.stream()
+                        .filter(m -> m.getMemoId().equals(targetId))
+                        .findFirst()
+                        .ifPresent(m -> m.changeOrder(index));
+            }
+
+            // 3. 변경된 리스트 전체를 다시 응답 (STOMP)
+            // 프론트엔드는 이 리스트로 화면을 갈아끼움
+            List<MemoResponse> responseList = memos.stream()
+                    .map(MemoResponse::new)
+                    .collect(Collectors.toList());
+
+            sendStompMessage(block.getPlan().getPlanId(), "MEMO_REORDERED", responseList);
 
         } finally {
             unlock(lockKey);


### PR DESCRIPTION
## 📌관련 이슈
- closed: #84 
## 💥작업 내용
- orderIndex 필드 추가[memo]
- 메모 생성시 후순위로 순서 부여
- ID 리스트 순서대로 orderIndex 재설정 로직
- 순서 변경 api 테스트
  - order_index가 바뀐것을 알 수 있음
  
<img width="807" height="158" alt="1" src="https://github.com/user-attachments/assets/082d3f0c-b31e-4221-b002-2a0c78a87a0e" />
<img width="810" height="465" alt="순서" src="https://github.com/user-attachments/assets/8f46661e-673c-4960-a86c-916139c08272" />
<img width="828" height="147" alt="2" src="https://github.com/user-attachments/assets/7ff7f223-be1d-43d3-88a2-5ccd2e2b2983" />

## ✨참고 사항 
- 순서 로직
  1. 클라이언트: 드래그 앤 드롭으로 정렬된 ID 배열 전송 (예: `[ID_C, ID_A, ID_B]`)
  2. 서버: 배열의 인덱스를 순서 값으로 매핑 (`ID_C`→0, `ID_A`→1, `ID_B`→2)
  3. DB: 매핑된 값으로 `order_index` 컬럼 일괄 업데이트


