### PR TITLE
Feature : plan scheduleblock 목록 조회 api 및 스크래핑 api test

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/MemoController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/MemoController.java
@@ -22,10 +22,12 @@ public class MemoController {
     private final MemoService memoService;
 
     // 메모 생성
-    @PostMapping
-    public ResponseEntity<Void> createMemo(@RequestBody MemoRequest request) {
+    @PostMapping("/{blockId}")
+    public ResponseEntity<Void> createMemo(
+            @PathVariable Long blockId,
+            @RequestBody MemoRequest request) {
         // blockId를 DTO에서 꺼내서 넘김
-        memoService.createMemo(request.getBlockId(), request);
+        memoService.createMemo(blockId, request);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/PlanController.java
@@ -1,9 +1,6 @@
 package com.practice.OAuth2.domain.plan.controller;
 
-import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
-import com.practice.OAuth2.domain.plan.dto.PlanJoinRequest;
-import com.practice.OAuth2.domain.plan.dto.PlanResponse;
-import com.practice.OAuth2.domain.plan.dto.PlanUpdateRequest;
+import com.practice.OAuth2.domain.plan.dto.*;
 import com.practice.OAuth2.domain.plan.service.PlanService;
 import com.practice.OAuth2.domain.user.entity.User;
 import com.practice.OAuth2.domain.user.repository.UserRepository;
@@ -12,18 +9,16 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/api/plans")
 public class PlanController {
     private final PlanService planService;
+    private final UserRepository userRepository;
 
     // 여행 생성
     @PostMapping()
@@ -34,6 +29,14 @@ public class PlanController {
 
         PlanResponse response = planService.createPlan(request, principal.getId());
         return ResponseEntity.ok(response);
+    }
+
+    // 여행 목록 조회
+    @GetMapping()
+    public ResponseEntity<List<PlanListResponse>> getMyPlans(
+            @AuthenticationPrincipal UserPrincipal principal
+    ) {
+        return ResponseEntity.ok(planService.getMyPlans(principal.getId()));
     }
 
     // 초대 코드로 입장

--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
@@ -1,5 +1,6 @@
 package com.practice.OAuth2.domain.plan.controller;
 
+import com.practice.OAuth2.domain.plan.dto.ScheduleBlockResponse;
 import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
 import com.practice.OAuth2.domain.plan.dto.ScheduleMoveRequest;
 import com.practice.OAuth2.domain.plan.service.ScheduleService;
@@ -9,13 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.security.core.userdetails.UserDetails;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
 
 @RestController
 @RequiredArgsConstructor
@@ -33,6 +30,17 @@ public class ScheduleController {
     ) {
         scheduleService.createScheduleBlock(planId, request);
         return ResponseEntity.ok().build();
+    }
+
+    // 스케줄 블럭 조회
+    @GetMapping("/{planId}")
+    public ResponseEntity<List<ScheduleBlockResponse>> getSchedules(
+            @PathVariable Long planId,
+            @AuthenticationPrincipal UserDetails userDetails
+    ) {
+        User user = userRepository.findByEmail(userDetails.getUsername()).orElseThrow();
+
+        return ResponseEntity.ok(scheduleService.getSchedules(user.getUserId(), planId));
     }
 
     // 스케줄 블록 시간 늘리기

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/MemoResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/MemoResponse.java
@@ -12,6 +12,7 @@ public class MemoResponse {
     private String content;
     private String linkUrl;
     private String type;
+    private Integer orderIndex;
 
     // Entity -> DTO 변환 생성자
     public MemoResponse(Memo memo) {
@@ -20,5 +21,6 @@ public class MemoResponse {
         this.content = memo.getContent();
         this.linkUrl = memo.getLinkUrl();
         this.type = memo.getType();
+        this.orderIndex = memo.getOrderIndex();
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanCreateRequest.java
@@ -1,5 +1,6 @@
 package com.practice.OAuth2.domain.plan.dto;
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.practice.OAuth2.domain.plan.entity.Plan;
 import java.time.LocalDate;
 import lombok.Getter;
@@ -15,9 +16,11 @@ public class PlanCreateRequest {
     private String title;
 
     @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate startDate;
 
     @NonNull
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
     private LocalDate endDate;
 
 //    // DTO -> Entity 변환 메서드 (서비스 로직 단축용)

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanListResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/PlanListResponse.java
@@ -1,0 +1,23 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import com.practice.OAuth2.domain.plan.entity.Plan;
+import lombok.Getter;
+
+import java.time.LocalDate;
+
+@Getter
+public class PlanListResponse {
+    private Long planId;
+    private String title;
+    private LocalDate startDate;
+    private LocalDate endDate;
+    private String planImageUrl;
+
+    public PlanListResponse(Plan plan) {
+        this.planId = plan.getPlanId();
+        this.title = plan.getTitle();
+        this.startDate = plan.getStartDate();
+        this.endDate = plan.getEndDate();
+        this.planImageUrl = plan.getPlanImageUrl();
+    }
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleBlockResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleBlockResponse.java
@@ -3,6 +3,9 @@ package com.practice.OAuth2.domain.plan.dto;
 import com.practice.OAuth2.domain.attraction.dto.AttractionResponse;
 import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
 import java.time.LocalTime;
+import java.util.List;
+import java.util.stream.Collectors;
+
 import lombok.Getter;
 
 @Getter
@@ -14,6 +17,7 @@ public class ScheduleBlockResponse {
     private String title;
     private LocalTime startTime;
     private LocalTime endTime;
+    private List<MemoResponse> memos;
 
     public ScheduleBlockResponse(ScheduleBlock block) {
         this.blockId = block.getBlockId();
@@ -28,5 +32,12 @@ public class ScheduleBlockResponse {
         this.title = block.getTitle();
         this.startTime = block.getStartTime();
         this.endTime = block.getEndTime();
+
+        // 엔티티의 메모 리스트를 DTO 리스트로 변환
+        if (block.getMemos() != null) {
+            this.memos = block.getMemos().stream()
+                    .map(MemoResponse::new)
+                    .collect(Collectors.toList());
+        }
     }
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/Memo.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/Memo.java
@@ -17,6 +17,8 @@ import lombok.NoArgsConstructor;
 import org.hibernate.annotations.SQLDelete;
 import org.hibernate.annotations.Where;
 
+import java.time.LocalDateTime;
+
 @Entity
 @Getter
 @NoArgsConstructor
@@ -47,6 +49,9 @@ public class Memo extends BaseEntity {
 
     @Column(name = "order_index")
     private Integer orderIndex;
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
 
     public void update(String content, String linkUrl, String type) {
         this.content = content;

--- a/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/entity/ScheduleBlock.java
@@ -2,18 +2,14 @@ package com.practice.OAuth2.domain.plan.entity;
 
 import com.practice.OAuth2.domain.attraction.entity.Attraction;
 import com.practice.OAuth2.global.common.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -58,6 +54,13 @@ public class ScheduleBlock extends BaseEntity {
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt;
+
+    // 양방향 매핑 추가
+    // 블록 조회할때 메모도 같이 조회
+    @OneToMany(mappedBy = "scheduleBlock", fetch = FetchType.LAZY, cascade = CascadeType.ALL)
+    @OrderBy("orderIndex ASC")
+    @Builder.Default
+    private List<Memo> memos = new ArrayList<>();
 
     // 블록 옮기기
     public void changePosition(Integer day, LocalTime startTime) {

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanMemberRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/PlanMemberRepository.java
@@ -19,7 +19,7 @@ public interface PlanMemberRepository extends JpaRepository<PlanMember, Long> {
 
     // 2. 내가 참여 중인 여행 목록 조회
     @EntityGraph(attributePaths = {"plan"})
-    List<PlanMember> findByUser_UserIdAndLeftAtIsNull(Long userId);
+    List<PlanMember> findByUser_UserIdAndLeftAtIsNullOrderByCreatedAtDesc(Long userId);
 
     // 3. 특정 유저가 이 방에 들어온 적이 있는지 확인 (재입장 로직용)
     // leftAt 상관없이 기록 자체를 찾음

--- a/src/main/java/com/practice/OAuth2/domain/plan/repository/ScheduleBlockRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/repository/ScheduleBlockRepository.java
@@ -2,8 +2,15 @@ package com.practice.OAuth2.domain.plan.repository;
 
 import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
 import java.util.List;
+
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface ScheduleBlockRepository extends JpaRepository<ScheduleBlock, Long> {
+
+    // 특정 planId에 속한 모든 스케줄 블록을 DB에서 긁어오기
+    // 가져올 때 1일 차 → 2일 차 순서로, 같은 날짜 내에서는 아침 → 저녁 순서로 정렬해서 가져오기
+    // 엔티티그래프 설정 : 스케줄 블록 가져올 때 attraction 정보도 미리 조인(JOIN FETCH)해서 한 방에 가져와
+    @EntityGraph(attributePaths = {"attraction"})
     List<ScheduleBlock> findAllByPlan_PlanIdOrderByDayAscStartTimeAsc(Long planId);
 }

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/PlanService.java
@@ -1,10 +1,6 @@
 package com.practice.OAuth2.domain.plan.service;
 
-import com.practice.OAuth2.domain.plan.dto.PlanCreateRequest;
-import com.practice.OAuth2.domain.plan.dto.PlanJoinRequest;
-import com.practice.OAuth2.domain.plan.dto.PlanMemberResponse;
-import com.practice.OAuth2.domain.plan.dto.PlanResponse;
-import com.practice.OAuth2.domain.plan.dto.PlanUpdateRequest;
+import com.practice.OAuth2.domain.plan.dto.*;
 import com.practice.OAuth2.domain.plan.entity.Plan;
 import com.practice.OAuth2.domain.plan.entity.PlanMember;
 import com.practice.OAuth2.domain.plan.repository.PlanMemberRepository;
@@ -14,8 +10,11 @@ import com.practice.OAuth2.domain.user.repository.UserRepository;
 
 import java.time.LocalDate;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.messaging.simp.SimpMessagingTemplate;
 import org.springframework.stereotype.Service;
@@ -77,6 +76,19 @@ public class PlanService {
         } else {
             return WINTER_IMAGE; // 12, 1, 2월 -> 겨울
         }
+    }
+
+    // 여행 목록 조회
+    @Transactional(readOnly = true)
+    public List<PlanListResponse> getMyPlans(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 사용자"));
+
+        // 내가 참여 중인 PlanMember 리스트 조회 -> Plan 정보 추출 -> DTO 변환
+        // (PlanMemberRepository에 해당 메서드가 정의되어 있어야 함)
+        return planMemberRepository.findByUser_UserIdAndLeftAtIsNullOrderByCreatedAtDesc(userId).stream()
+                .map(pm -> new PlanListResponse(pm.getPlan()))
+                .collect(Collectors.toList());
     }
 
     // 친구 초대

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
@@ -5,12 +5,16 @@ import com.practice.OAuth2.domain.attraction.repository.AttractionRepository;
 import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
 import com.practice.OAuth2.domain.plan.entity.Plan;
 import com.practice.OAuth2.domain.plan.entity.ScheduleBlock;
+import com.practice.OAuth2.domain.plan.repository.PlanMemberRepository;
 import com.practice.OAuth2.domain.plan.repository.PlanRepository;
 import com.practice.OAuth2.domain.plan.repository.ScheduleBlockRepository;
 import java.time.LocalTime;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.cache.CacheProperties.Redis;
 import org.springframework.data.redis.core.StringRedisTemplate;
@@ -28,6 +32,7 @@ public class ScheduleService {
     private final PlanRepository planRepository;
     private final AttractionRepository attractionRepository;
     private final ScheduleBlockRepository scheduleBlockRepository;
+    private final PlanMemberRepository planMemberRepository;
 
     // 알림 전송용(web socket)
     private final SimpMessagingTemplate messagingTemplate;
@@ -37,6 +42,26 @@ public class ScheduleService {
 
     // Redis Lock 키 접두사
     private static final String LOCK_PREFIX = "plan:lock:";
+
+    // 내 여행계획의 스케줄 조회
+    @Transactional(readOnly = true)
+    public List<ScheduleBlockResponse> getSchedules(Long userId, Long planId) {
+
+        // 권한 체크
+        boolean isMember = planMemberRepository.existsByPlan_PlanIdAndUser_UserIdAndLeftAtIsNull(planId, userId);
+
+        if (!isMember) {
+            throw new IllegalArgumentException("이 여행에 접근할 권한이 없습니다.");
+        }
+
+        // 스케줄 조회 (날짜 -> 시간 순)
+        List<ScheduleBlock> blocks = scheduleBlockRepository.findAllByPlan_PlanIdOrderByDayAscStartTimeAsc(planId);
+
+        // DTO 변환
+        return blocks.stream()
+                .map(ScheduleBlockResponse::new)
+                .collect(Collectors.toList());
+    }
 
     // 블록 생성
     public void createScheduleBlock(Long planId, ScheduleCreateRequest request) {

--- a/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
@@ -8,6 +8,7 @@ import org.springframework.stereotype.Service;
 
 import java.io.IOException;
 
+
 @Service
 public class UrlMetadataService {
 
@@ -19,6 +20,20 @@ public class UrlMetadataService {
                     .referrer("http://www.google.com")
                     .timeout(5000)
                     .get();
+
+            // 네이버 전용 (iframe)
+            if (url.contains("blog.naver.com")) {
+                Element iframe = doc.select("iframe#mainFrame").first();
+                if (iframe != null) {
+                    String realUrl = "https://blog.naver.com" + iframe.attr("src");
+                    // 진짜 주소로 문서를 교체 (덮어쓰기)
+                    doc = Jsoup.connect(realUrl)
+                            .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36")
+                            .referrer("http://www.google.com")
+                            .timeout(5000)
+                            .get();
+                }
+            }
 
             // 2. Open Graph 태그 파싱
             String title = getMetaTagContent(doc, "og:title");

--- a/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
@@ -16,6 +16,7 @@ public class UrlMetadataService {
             // 1. 해당 URL의 HTML 문서를 가져옴 (타임아웃 5초 설정)
             Document doc = Jsoup.connect(url)
                     .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36") // 브라우저인 척 위장
+                    .referrer("http://www.google.com")
                     .timeout(5000)
                     .get();
 
@@ -46,10 +47,15 @@ public class UrlMetadataService {
     }
 
     // 메타 태그 내용 추출 헬퍼 메서드
-    private String getMetaTagContent(Document doc, String property) {
-        Element element = doc.select("meta[property=" + property + "]").first();
-        if (element != null) {
-            return element.attr("content");
+    private String getMetaTagContent(Document doc, String... keys) {
+        for (String key : keys) {
+            // 1. property="key" 검색 (예: <meta property="og:image">)
+            Element element = doc.select("meta[property=" + key + "]").first();
+            if (element != null) return element.attr("content");
+
+            // 2. name="key" 검색 (예: <meta name="twitter:image">)
+            element = doc.select("meta[name=" + key + "]").first();
+            if (element != null) return element.attr("content");
         }
         return null;
     }

--- a/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/service/UrlMetadataService.java
@@ -15,7 +15,7 @@ public class UrlMetadataService {
         try {
             // 1. 해당 URL의 HTML 문서를 가져옴 (타임아웃 5초 설정)
             Document doc = Jsoup.connect(url)
-                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3") // 브라우저인 척 위장
+                    .userAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36") // 브라우저인 척 위장
                     .timeout(5000)
                     .get();
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #86
## 💥작업 내용
- 여행 목록 조회 API 구현
- memo, scheduleBlock 양방향 매핑 (조회 위해서)
- 여행 스케줄(전체 블럭) 조회 API 구현
- 메모 순서 이동 indexorder dto에 누락한것 추가 
- usermetadataService chrome버전 업그레이드
- 네이버 블로그 스크래핑 로직 강화(iframe으로 진짜 주소 찾기)
- 스크래핑->이미지 가져오기 API 테스트
  <img width="500" height="300" alt="사진 스크래핑" src="https://github.com/user-attachments/assets/e478aa00-cf3e-4b30-bef3-5a19bf5c8855" />

## ✨참고 사항 
- 네이버 블로그의 URL구조는 'iframe'이라는 구조 사용. 껍데기(알맹이) 구조이기에 iframe이라는 태그를 찾아 실제 주소를 이용해 메타데이터를 찾아내야한다. 


