### PR TITLE
Modify : scheduleblock resize 로직 변경 및 scrap개수 조회 추가 구현

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/controller/ScheduleController.java
@@ -3,6 +3,7 @@ package com.practice.OAuth2.domain.plan.controller;
 import com.practice.OAuth2.domain.plan.dto.ScheduleBlockResponse;
 import com.practice.OAuth2.domain.plan.dto.ScheduleCreateRequest;
 import com.practice.OAuth2.domain.plan.dto.ScheduleMoveRequest;
+import com.practice.OAuth2.domain.plan.dto.ScheduleResizeRequest;
 import com.practice.OAuth2.domain.plan.service.ScheduleService;
 import com.practice.OAuth2.domain.user.entity.User;
 import com.practice.OAuth2.domain.user.repository.UserRepository;
@@ -58,9 +59,10 @@ public class ScheduleController {
     // 스케줄 블록 시간 늘리기
     @PatchMapping("/{blockId}/resize")
     public ResponseEntity<Void> resizeBlock(
-            @PathVariable Long blockId
+            @PathVariable Long blockId,
+            @RequestBody ScheduleResizeRequest request
     ) {
-        scheduleService.resizeScheduleBlock(blockId);
+        scheduleService.resizeScheduleBlock(blockId, request.getNewEndTime());
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleResizeRequest.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/dto/ScheduleResizeRequest.java
@@ -1,0 +1,12 @@
+package com.practice.OAuth2.domain.plan.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalTime;
+
+@Getter
+@NoArgsConstructor
+public class ScheduleResizeRequest {
+    private LocalTime newEndTime;
+}

--- a/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
+++ b/src/main/java/com/practice/OAuth2/domain/plan/service/ScheduleService.java
@@ -124,11 +124,10 @@ public class ScheduleService {
     }
 
     // 블럭 크기 조절
-    public void resizeScheduleBlock(Long blockId) {
+    public void resizeScheduleBlock(Long blockId, LocalTime newEndTime) {
         ScheduleBlock block = scheduleBlockRepository.findById(blockId)
                 .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 블록입니다."));
 
-        // [STOMP] 변경된 정보 전송 (Type: UPDATE)
         Long planId = block.getPlan().getPlanId();
 
         String lockKey = LOCK_PREFIX + planId;
@@ -137,10 +136,7 @@ public class ScheduleService {
         }
 
         try{
-            LocalTime currentEndTime = block.getEndTime();
-            LocalTime newEndTime = currentEndTime.plusMinutes(30);
-
-            // 시간 업데이트 (엔티티 내부에 updateEndTime 메서드 필요)
+            // 프론트엔드에서 계산된 newEndTime 적용
             block.updateEndTime(newEndTime);
 
             ScheduleBlockResponse response = new ScheduleBlockResponse(block);
@@ -210,14 +206,7 @@ public class ScheduleService {
         }
     }
 
-    /**
-     * STOMP 메시지 전송 공통 메서드
-     * 구독 주소: /topic/plans/{planId}
-     * 메시지 구조:
-     * { "event": "이벤트명",
-     * "data": { ... }
-     * }
-     */
+    // STOMP 메시지 전송 공통 메서드
     private void sendStompMessage(Long planId, String eventType, Object data) {
         Map<String, Object> message = new HashMap<>();
         message.put("event", eventType);

--- a/src/main/java/com/practice/OAuth2/domain/scrap/dto/ScrapFolderResponse.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/dto/ScrapFolderResponse.java
@@ -12,18 +12,12 @@ public class ScrapFolderResponse {
     private Long folderId;
     private String name;
     private String folderImageUrl;
-    
-    public static ScrapFolderResponse from(ScrapFolder folder) {
-        return ScrapFolderResponse.builder()
-                .folderId(folder.getFolderId())
-                .name(folder.getName())
-                .folderImageUrl(folder.getFolderImageUrl())
-                .build();
-    }
+    private Integer scrapCount;
 
-    public ScrapFolderResponse(ScrapFolder folder, String latestImageUrl) {
+    public ScrapFolderResponse(ScrapFolder folder, String latestImageUrl, Integer scrapCount) {
         this.folderId = folder.getFolderId(); // 엔티티 필드명 확인 (getId or getFolderId)
         this.name = folder.getName();
+        this.scrapCount = scrapCount;
 
         // 이미지가 있으면 그 이미지를, 없으면 기본 이미지(placeholder)를 사용
         if (latestImageUrl != null && !latestImageUrl.isEmpty()) {

--- a/src/main/java/com/practice/OAuth2/domain/scrap/repository/ScrapRepository.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/repository/ScrapRepository.java
@@ -14,4 +14,7 @@ public interface ScrapRepository extends JpaRepository<Scrap, Long> {
     // 특정 폴더의 스크랩 중 가장 최신(Top 1) 데이터 조회
     // ORDER BY created_at DESC LIMIT 1
     Optional<Scrap> findTopByScrapFolderOrderByCreatedAtDesc(ScrapFolder scrapFolder);
+
+    // 특정 폴더의 스크랩 개수 조회
+    int countByScrapFolder(ScrapFolder scrapFolder);
 }

--- a/src/main/java/com/practice/OAuth2/domain/scrap/service/ScrapService.java
+++ b/src/main/java/com/practice/OAuth2/domain/scrap/service/ScrapService.java
@@ -58,8 +58,11 @@ public class ScrapService {
                 thumbnailParams = latestScrap.getImageUrl();
             }
 
+            // 스크랩 개수
+            int count = scrapRepository.countByScrapFolder(folder);
+
             // DTO 생성자 호출 (폴더 정보 + 최신 이미지 URL)
-            return new ScrapFolderResponse(folder, thumbnailParams);
+            return new ScrapFolderResponse(folder, thumbnailParams, count);
         }).collect(Collectors.toList());
     }
 


### PR DESCRIPTION
## 📌관련 이슈
- closed: #95
## 💥작업 내용
- 프론트에서 endtime 보내주면 서버에서 새로 수정해서 resize
- scrapfolder response dto에 from정적 메서드 삭제
  - imageUrl이나 scrapCount는 동적 변수라 사용하기 어려움
- scrapFolders 전체 리스트 조회시 scrapCount도 반환 
## ✨참고 사항 
- 


