### PR TITLE
Fix/#105 중복 식별자 문제 attraction이 gugun을 찾을 때

### DIFF
--- a/src/main/java/com/practice/OAuth2/domain/attraction/entity/Attraction.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/entity/Attraction.java
@@ -8,6 +8,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.JoinColumns;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import java.math.BigDecimal;
@@ -28,8 +29,14 @@ public class Attraction extends BaseEntity {
     @JoinColumn(name = "sido_code", referencedColumnName = "sido_code")
     private Sido sido;
 
+    @Column(name = "gugun_code")
+    private Integer gugunCode;
+
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "gugun_code", referencedColumnName = "gugun_code")
+    @JoinColumns({
+            @JoinColumn(name = "gugun_code", referencedColumnName = "gugun_code", insertable = false, updatable = false),
+            @JoinColumn(name = "sido_code", referencedColumnName = "sido_code", insertable = false, updatable = false)
+    })
     private Gugun gugun;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/practice/OAuth2/domain/attraction/entity/Attraction.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/entity/Attraction.java
@@ -29,6 +29,7 @@ public class Attraction extends BaseEntity {
     @JoinColumn(name = "sido_code", referencedColumnName = "sido_code")
     private Sido sido;
 
+
     @Column(name = "gugun_code")
     private Integer gugunCode;
 

--- a/src/main/java/com/practice/OAuth2/domain/attraction/entity/Gugun.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/entity/Gugun.java
@@ -18,7 +18,10 @@ public class Gugun extends BaseEntity {
     @JoinColumn(name = "sido_code", referencedColumnName = "sido_code")
     private Sido sido;
 
-    @Column(name = "gugun_code", nullable = false, unique=true)
+    @Column(name = "sido_code", insertable = false, updatable = false)
+    private Integer sidoCode;
+
+    @Column(name = "gugun_code", nullable = false)
     private Integer gugunCode;
 
     @Column(name = "gugun_name", length = 20)

--- a/src/main/java/com/practice/OAuth2/domain/attraction/entity/Gugun.java
+++ b/src/main/java/com/practice/OAuth2/domain/attraction/entity/Gugun.java
@@ -26,4 +26,5 @@ public class Gugun extends BaseEntity {
 
     @Column(name = "gugun_name", length = 20)
     private String gugunName;
+
 }


### PR DESCRIPTION
## 📌관련 이슈
- closed: #105 
## 💥작업 내용
 1. `build.gradle` 롤백: Lombok 버전을 명시했던 코드를 삭제하고 기존의 라이브러리 관리 방식을 유지하도록 되돌렸습니다.
 2. `Attraction.java` (복합키 및 매핑 해결):
       * Gugun과의 관계를 gugun_code와 sido_code 두 컬럼으로 연결하여 중복 식별자 오류(More than one row...)를
         해결했습니다.
       * 연결 컬럼에 insertable = false, updatable = false를 설정하여 설정 충돌 에러(mix insertable)를 해결했습니다.
       * 쓰기 작업을 위해 gugunCode 필드를 별도로 추가했습니다.
 3. `Gugun.java` (매핑 인식 해결):
       * Attraction에서 sido_code를 참조할 수 있도록 sidoCode 필드를 읽기 전용으로 추가하여 참조 컬럼 미매핑 에러를
         해결했습니다.
       * 중복이 발생하는 gugun_code 컬럼의 unique = true 설정을 제거했습니다.
## ✨참고 사항 
- 


